### PR TITLE
RTR widget changes actual temperature instead of set temperature

### DIFF
--- a/widgets/widget.js
+++ b/widgets/widget.js
@@ -1195,7 +1195,7 @@ $(document).on('pagecreate', function (bevent, bdata) {
 		'click': function (event, response) {
 			var node = $(this).parent().parent();
 			var step = node.attr('data-step') * $(this).attr('data-sign');
-			var item = node.find('.temp span').attr('data-item');
+			var item = node.find('.set .temp span').attr('data-item');
 
 			var temp = (Math.round((widget.get(item) * 1 + step) * 10) / 10).toFixed(1);
 			io.write(item, temp);


### PR DESCRIPTION
Using the plus/minus buttons in the rtr widget changes the actual temperature instead
of the set temperature. This seems to be because of a wrong jquery selector.
Fixed the jquery selector.