### PR TITLE
Escape src parameter in multimedia.image

### DIFF
--- a/widgets/multimedia.html
+++ b/widgets/multimedia.html
@@ -31,11 +31,11 @@
 		src="pages/base/pics/trans.png" />
 
 	<script type="text/javascript">
-		var noCacheSrc ='{{ src }}' +  (('{{ src }}'.indexOf('?') == -1) ? '?' : '&') + '_=' + new Date().getTime();
+		var noCacheSrc ='{{ src|escape('js') }}' +  (('{{ src }}'.indexOf('?') == -1) ? '?' : '&') + '_=' + new Date().getTime();
 		$('#{{ uid(page, id) }}').attr('src', noCacheSrc);
 
 		setInterval(function () {
-			var noCacheSrc ='{{ src }}' +  (('{{ src }}'.indexOf('?') == -1) ? '?' : '&') + '_=' + new Date().getTime();
+			var noCacheSrc ='{{ src|escape('js') }}' +  (('{{ src }}'.indexOf('?') == -1) ? '?' : '&') + '_=' + new Date().getTime();
 			$('#{{ uid(page, id) }}').attr('src', noCacheSrc);
 		}, new Date().duration('{{time|default("10i")}}'));
 	</script>


### PR DESCRIPTION
A source-url with ampersand (&) is not working.
Example (get image from Zoneminder): http://192.168.1.45:8080/zm/cgi-bin/nph-zms?mode=single&monitor=1&scale=100
smartVISU output is: http://192.168.1.45:8080/zm/cgi-bin/nph-zms?mode=single&amp;monitor=1&amp;scale=100