### PR TITLE
fix IE11? - because port is not always set

### DIFF
--- a/driver/io_smarthome.py.js
+++ b/driver/io_smarthome.py.js
@@ -122,8 +122,8 @@ var io = {
 				if (location.port != '') {
 					io.port = location.port;
 				} else {
-					if (location.protocol == 'http:') io.port = '80'
-					if (location.protocol == 'https:') io.port = '443'
+					if (location.protocol == 'http:') io.port = '80';
+					if (location.protocol == 'https:') io.port = '443';
 				}
 			}
 		}

--- a/driver/io_smarthome.py.js
+++ b/driver/io_smarthome.py.js
@@ -119,7 +119,12 @@ var io = {
 			}
 			if (!io.port) {
 				// use port of current page if not defined and needed
-				io.port = location.port;
+				if (location.port != '') {
+					io.port = location.port;
+				} else {
+					if (location.protocol == 'http:') io.port = '80'
+					if (location.protocol == 'https:') io.port = '443'
+				}
 			}
 		}
 		io.socket = new WebSocket(protocol + io.address + ':' + io.port);


### PR DESCRIPTION
Hi, today I found, that IE was not working with the new change we made in #171 

While I debug the issue I found, that IE don't set location.port when the website run's on default ports.
So the following line "io.socket = new WebSocket(protocol + io.address + ':' + io.port);" throws a error.
