### PR TITLE
Update calender.php for correct timezone setting

### DIFF
--- a/lib/calendar/calendar.php
+++ b/lib/calendar/calendar.php
@@ -67,8 +67,8 @@ class calendar extends service
 		// output events as listj
 		foreach ($events as $event) {
 			$this->addData(array(
-				'start' => $ical->iCalDateToUnixTimestamp($event->dtstart),
-				'end' => $event->dtend != null ? $ical->iCalDateToUnixTimestamp($event->dtend) : $ical->iCalDateToUnixTimestamp($event->dtstart),
+				'start' => $ical->iCalDateToUnixTimestamp($event->dtstart, true),
+				'end' => $event->dtend != null ? $ical->iCalDateToUnixTimestamp($event->dtend, true) : $ical->iCalDateToUnixTimestamp($event->dtstart, true),
 				'title' => $event->summary,
 				'content' => str_replace("\\n", "\n", $event->description),
 				'where' => $event->location,


### PR DESCRIPTION
Add parameter forceTimeZone=true to function call iCalDateToUnixTimestamp to force usage of timezone data of the ics file. Otherwise (in my setup) the calender timezone is allways converted to utc.