### PR TITLE
Additional Feature: check if asset exists

### DIFF
--- a/pages/base/root.html
+++ b/pages/base/root.html
@@ -38,7 +38,7 @@
 	<link rel="icon" href="favicon.ico" type="image/x-icon" />
 	<link rel="apple-touch-icon" href="favicon.png" />
 	<link rel="manifest" href="index.php?page=manifest">
-	
+
 	<link rel="stylesheet" href="vendor/jquery.mobile/jquery.mobile.structure-1.4.5.min.css" />
 
 /** CSS assets **/
@@ -110,10 +110,10 @@
 	</script>
 
 	<script type="text/javascript" src="vendor/jquery.mobile/jquery.mobile-1.4.5.min.js"></script>
-	
+
 /** JavaScript assets **/
 {% set jsFiles = [
-		'lib/base/jquery.mobile.slider.js', 
+		'lib/base/jquery.mobile.slider.js',
 		'vendor/plot.highcharts/highstock.js',
 		'vendor/plot.highcharts/highcharts-more.js',
 		'vendor/plot.highcharts/draggable-points.js',
@@ -126,7 +126,7 @@
 		'lib/base/base.js',
 		'lib/base/base.php',
 		'driver/io_' ~ config_driver ~ '.js',
-		'pages/' ~ config_pages ~ '/visu.js' 
+		'pages/' ~ config_pages ~ '/visu.js'
 	] %}
 {% for file in dir('widgets', '(.*)(\.js)') %}
 	{% set jsFiles = jsFiles|merge([file.path]) %}
@@ -203,7 +203,8 @@
 
 	$.mobile.page.prototype.options.domCache = {{ (config_cache_dom ? 'true' : 'false') }};
 </script>
-
+<link rel="stylesheet" href="pages/base/quad.css" />
+<script type="text/javascript" src="widgets/quad.js"></script>
 {% import "lib.html" as lib %}
 {% import "basic.html" as basic %}
 {% import "calendar.html" as calendar %}

--- a/vendor/Twig/Environment.php
+++ b/vendor/Twig/Environment.php
@@ -114,6 +114,7 @@ class Twig_Environment
         $this->strictVariables = (bool) $options['strict_variables'];
         $this->setCache($options['cache']);
 
+        $this->addExtension(new Twig_Extension_AssetExistsExtension());
         $this->addExtension(new Twig_Extension_Core());
         $this->addExtension(new Twig_Extension_Escaper($options['autoescape']));
         $this->addExtension(new Twig_Extension_Optimizer($options['optimizations']));

--- a/vendor/Twig/Extension/AssetExistsExtension.php
+++ b/vendor/Twig/Extension/AssetExistsExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+class Twig_Extension_AssetExistsExtension extends Twig_Extension
+{
+
+    public function getFunctions()
+    {
+        return array(
+                'asset_exists' => new Twig_Function_Method($this, 'asset_exists'),
+        );
+    }
+
+    public function asset_exists($path)
+    {
+        $webRoot = realpath(dirname(__DIR__, 3));
+        $toCheck = $webRoot . '/widgets/' . $path;
+        // check if the file exists
+        if (!is_file($toCheck))
+        {
+            return false;
+        }
+
+        // check if file is well contained in web/ directory (prevents ../ in paths)
+        if (strncmp($webRoot, $toCheck, strlen($webRoot)) !== 0)
+        {
+            return false;
+        }
+        return true;
+    }
+
+    public function getName()
+    {
+        return 'asset_exists';
+    }
+
+}

--- a/widgets/quad.html
+++ b/widgets/quad.html
@@ -1871,7 +1871,7 @@ the first one is the base color for values below first threshold, so pass one co
 
     {% if column == 'cover' and item_album %}
             {% set coverUrl       = item_album~'.currentalbumarturl' %}
-            {% set defCoverArtUrl = 'pics/cover_empty.jpg' %}
+            {% set defCoverArtUrl = 'pages/base/pics/trans.png' %}
             <a href="#{{ uid(page, id) }}cover_popup" data-rel="popup" data-position-to="window">
               {{ multimedia.image(id~'cover', coverUrl, 'corner', 0, defCoverArtUrl, item_title|default(coverUrl)) }}
             </a>

--- a/widgets/quad.html
+++ b/widgets/quad.html
@@ -347,7 +347,9 @@ the first one is the base color for values below first threshold, so pass one co
     {% import "device.html" as device %}
     {% import "plot.html" as plot %}
     {% import "popup.html" as popup %}
-	  {% import "stateengine.html" as stateengine %}
+    {% if asset_exists('stateengine.html') %}
+      {% import "stateengine.html" as stateengine %}
+    {% endif %}
 
 /**	{# most of the following code provides some dummy proofing concerning the column_order. Elements are only added when relevant items exist #} */
   {% set elements = {} %}
@@ -578,7 +580,7 @@ the first one is the base color for values below first threshold, so pass one co
         {% endif %}
 
 
-    {% if column == 'stateengine' and item_auto %}
+    {% if column == 'stateengine' and item_auto and stateengine is defined %}
             {% if extpopup[0] == 'stateengine' %}
                 {{ stateengine.state(id~'_state', item_auto~'.state_name', item_auto~'.lock', item_auto~'.release', config_stateengine_icons, config_stateengine_values, uid(page, id)~'list_extpopup') }}
                 {{ popup.extpopup(uid(page, id)~'list_extpopup', extpopup[1], extpopup[2], extpopup[3], extpopup[4], extpopup[5], extpopup[6], extpopup[7], extpopup[8], extpopup[9], extpopup[10], extpopup[11], extpopup[12], extpopup[13], extpopup[14], extpopup[15], extpopup[16], extpopup[17], extpopup[18], extpopup[19], extpopup[20]) }}
@@ -692,7 +694,9 @@ the first one is the base color for values below first threshold, so pass one co
     {% import "icon.html" as icon %}
     {% import "device.html" as device %}
     {% import "popup.html" as popup %}
-    /** {% import "stateengine.html" as stateengine %} *
+    {% if asset_exists('stateengine.html') %}
+      {% import "stateengine.html" as stateengine %}
+    {% endif %}
 
 /**	{# most of the following code provides some dummy proofing concerning the column_order. Elements are only added when relevant items exist #} */
   {% set elements = {} %}
@@ -998,7 +1002,7 @@ the first one is the base color for values below first threshold, so pass one co
 
         {% endif %}
 
-    {% if column == 'stateengine' and item_auto %}
+    {% if column == 'stateengine' and item_auto and stateengine is defined %}
             {% if extpopup[0] == 'stateengine' %}
                 {{ stateengine.state(id~'_state', item_auto~'.state_name', item_auto~'.lock', item_auto~'.release', config_stateengine_icons, config_stateengine_values, uid(page, id)~'list_extpopup') }}
                 {{ popup.extpopup(uid(page, id)~'list_extpopup', extpopup[1], extpopup[2], extpopup[3], extpopup[4], extpopup[5], extpopup[6], extpopup[7], extpopup[8], extpopup[9], extpopup[10], extpopup[11], extpopup[12], extpopup[13], extpopup[14], extpopup[15], extpopup[16], extpopup[17], extpopup[18], extpopup[19], extpopup[20]) }}
@@ -1107,8 +1111,9 @@ the first one is the base color for values below first threshold, so pass one co
     {% import "icon.html" as icon %}
     {% import "plot.html" as plot %}
     {% import "popup.html" as popup %}
-    {% import "extra.html" as extra %}
-    /** {% import "stateengine.html" as stateengine %} *
+    {% if asset_exists('stateengine.html') %}
+      {% import "stateengine.html" as stateengine %}
+    {% endif %}
 
 /**	{# convert array with uzsu and pos items to separate items #} */
   {% if pos_attribs is iterable %}
@@ -1421,7 +1426,7 @@ the first one is the base color for values below first threshold, so pass one co
             {% endif %}
         {% endif %}
 
-    {% if column == 'stateengine' and item_auto %}
+    {% if column == 'stateengine' and item_auto and stateengine is defined %}
             {% if extpopup[0] == 'stateengine' %}
                 {{ stateengine.state(id~'_state', item_auto~'.state_name', item_auto~'.lock', item_auto~'.release', config_stateengine_icons, config_stateengine_values, uid(page, id)~'list_extpopup') }}
                 {{ popup.extpopup(uid(page, id)~'list_extpopup', extpopup[1], extpopup[2], extpopup[3], extpopup[4], extpopup[5], extpopup[6], extpopup[7], extpopup[8], extpopup[9], extpopup[10], extpopup[11], extpopup[12], extpopup[13], extpopup[14], extpopup[15], extpopup[16], extpopup[17], extpopup[18], extpopup[19], extpopup[20]) }}
@@ -1581,9 +1586,10 @@ the first one is the base color for values below first threshold, so pass one co
     {% import "basic.html" as basic %}
     {% import "plot.html" as plot %}
     {% import "device.html" as device %}
-    {% import "extra.html" as extra %}
     {% import "multimedia.html" as multimedia %}
-    /** {% import "stateengine.html" as stateengine %} *
+    {% if asset_exists('stateengine.html') %}
+      {% import "stateengine.html" as stateengine %}
+    {% endif %}
 
 /**	{# most of the following code provides some dummy proofing concerning the column_order. Elements are only added when relevant items exist #} */
   {% set elements = {} %}
@@ -1867,10 +1873,12 @@ the first one is the base color for values below first threshold, so pass one co
             {% set coverUrl       = item_album~'.currentalbumarturl' %}
             {% set defCoverArtUrl = 'pics/cover_empty.jpg' %}
             <a href="#{{ uid(page, id) }}cover_popup" data-rel="popup" data-position-to="window">
-              {{ extra.cover(id~'cover', coverUrl, defCoverArtUrl, item_title|default(coverUrl)) }}
+              {{ multimedia.image(id~'cover', coverUrl, 'corner', 0, defCoverArtUrl, item_title|default(coverUrl)) }}
             </a>
             <div id="{{ uid(page, id) }}cover_popup" data-role="popup" data-overlay-theme="a" class="quad_cover-popup">
-                <img class="coverbig" id="{{ uid(page, id) }}" data-widget="extra.cover" data-item="{{ coverUrl }}" src="{{ defCoverArtUrl }}"  onerror="javascript:this.src='{{ defCoverArtUrl }}'"/>
+                <img class="coverbig" id="{{ uid(page, id) }}" data-widget="multimedia.image"
+                data-time="0" data-item="{{ coverUrl }}{% if item_title %}, {{ item_title }}{% endif %}"
+                src="{{ defCoverArtUrl }}"  onerror="javascript:this.src='{{ defCoverArtUrl }}'"/>
             </div>
 
       {% if elements[loop.index] == 'div' %}
@@ -2020,7 +2028,7 @@ the first one is the base color for values below first threshold, so pass one co
             {% endif %}
         {% endif %}
 
-    {% if column == 'stateengine' and item_auto %}
+    {% if column == 'stateengine' and item_auto and stateengine is defined %}
             {% if extpopup[0] == 'stateengine' %}
                 {{ stateengine.state(id~'_state', item_auto~'.state_name', item_auto~'.lock', item_auto~'.release', config_stateengine_icons, config_stateengine_values, uid(page, id)~'list_extpopup') }}
                 {{ popup.extpopup(uid(page, id)~'list_extpopup', extpopup[1], extpopup[2], extpopup[3], extpopup[4], extpopup[5], extpopup[6], extpopup[7], extpopup[8], extpopup[9], extpopup[10], extpopup[11], extpopup[12], extpopup[13], extpopup[14], extpopup[15], extpopup[16], extpopup[17], extpopup[18], extpopup[19], extpopup[20]) }}
@@ -2137,7 +2145,9 @@ the first one is the base color for values below first threshold, so pass one co
     {% import "icon.html" as icon %}
     {% import "plot.html" as plot %}
     {% import "popup.html" as popup %}
-    {% import "stateengine.html" as stateengine %}
+    {% if asset_exists('stateengine.html') %}
+      {% import "stateengine.html" as stateengine %}
+    {% endif %}
 
 /**	{# most of the following code provides some dummy proofing concerning the column_order. Elements are only added when relevant items exist #} */
 {% if column_order %}
@@ -2447,7 +2457,7 @@ the first one is the base color for values below first threshold, so pass one co
                     {% endif %}
                 {% endif %}
 
-        {% if column == 'stateengine' and item_auto[i] %}
+        {% if column == 'stateengine' and item_auto[i] and stateengine is defined %}
                     {% if extpopup[i][0] == 'stateengine' %}
                         {{ stateengine.state(id~'_state'~z~i, item_auto[i]~'.state_name', item_auto[i]~'.lock', item_auto[i]~'.suspend', config_stateengine_icons, config_stateengine_values, uid(page, id)~'list_extpopup'~z~i) }}
                         {{ popup.extpopup(uid(page, id)~'list_extpopup'~z~i, extpopup[i][1], extpopup[i][2], extpopup[i][3], extpopup[i][4], extpopup[i][5], extpopup[i][6], extpopup[i][7], extpopup[i][8], extpopup[i][9], extpopup[i][10], extpopup[i][11], extpopup[i][12], extpopup[i][13], extpopup[i][14], extpopup[i][15], extpopup[i][16], extpopup[i][17], extpopup[i][18], extpopup[i][19]) }}
@@ -2578,13 +2588,13 @@ the first one is the base color for values below first threshold, so pass one co
 
                 {% endif %}
 
-        {% if column == 'stateengine' and item_auto %}
-                    {% if extpopup[i][0] == 'stateengine' or extpopup[0] == 'stateengine' %}
-                        {{ stateengine.state(id~'_state'~z~i, item_auto~'.state_name', item_auto~'.lock', item_auto~'.release', config_stateengine_icons, config_stateengine_values, uid(page, id)~'list_extpopup'~z~i) }}
-                        {{ popup.extpopup(uid(page, id)~'list_extpopup'~z~i, extpopup[1], extpopup[2], extpopup[3], extpopup[4], extpopup[5], extpopup[6], extpopup[7], extpopup[8], extpopup[9], extpopup[10], extpopup[11], extpopup[12], extpopup[13], extpopup[14], extpopup[15], extpopup[16], extpopup[17], extpopup[18], extpopup[19], extpopup[20]) }}
-                    {% else %}
-                        {{ stateengine.state(id~'_state'~z~i, item_auto~'.state_name', item_auto~'.lock', item_auto~'.release', config_stateengine_icons, config_stateengine_values) }}
-                    {% endif %}
+        {% if column == 'stateengine' and item_auto and stateengine is defined %}
+          {% if extpopup[i][0] == 'stateengine' or extpopup[0] == 'stateengine' %}
+              {{ stateengine.state(id~'_state'~z~i, item_auto~'.state_name', item_auto~'.lock', item_auto~'.release', config_stateengine_icons, config_stateengine_values, uid(page, id)~'list_extpopup'~z~i) }}
+              {{ popup.extpopup(uid(page, id)~'list_extpopup'~z~i, extpopup[1], extpopup[2], extpopup[3], extpopup[4], extpopup[5], extpopup[6], extpopup[7], extpopup[8], extpopup[9], extpopup[10], extpopup[11], extpopup[12], extpopup[13], extpopup[14], extpopup[15], extpopup[16], extpopup[17], extpopup[18], extpopup[19], extpopup[20]) }}
+          {% else %}
+              {{ stateengine.state(id~'_state'~z~i, item_auto~'.state_name', item_auto~'.lock', item_auto~'.release', config_stateengine_icons, config_stateengine_values) }}
+          {% endif %}
 
           {% if arrays[loop.index] == 'div' %}
             </div>
@@ -2638,7 +2648,7 @@ the first one is the base color for values below first threshold, so pass one co
         {% endif %}
       {% endif %}
 
-        {% if column == 'stateengine' and item_auto and type is iterable and item_auto is not iterable %}
+        {% if column == 'stateengine' and item_auto and type is iterable and item_auto is not iterable and stateengine is defined %}
                 {% for i,ext_array in extpopup %}
                     {% if extpopup[i][0] == 'stateengine' %}{% set ext = i %}{% endif %}
                 {% endfor %}


### PR DESCRIPTION
Instead of preventing a page from loading if an imported macro does not exist you can now use the following code:
{% if asset_exists('extra.html') %}
{% import 'extra.html' as extra %}
{% endif%}

You can the also use this if statement on the macro call itself:
{% if extra is defined %}