### PR TITLE
Docu for custom widgets

### DIFF
--- a/lib/functions_twig.php
+++ b/lib/functions_twig.php
@@ -113,6 +113,7 @@ function twig_dir($dir, $filter = '(.*)')
 			if (preg_match("#".$filter."$#i", $item, $itemparts) > 0)
 			{
 				$name = str_replace("_", " ", $itemparts[1]);
+
 				$ret[$name] = array(
 					"path" => $dir.'/'.$itemparts[0],
 					"file" => $itemparts[0],
@@ -126,7 +127,6 @@ function twig_dir($dir, $filter = '(.*)')
 
 	// sort
 	ksort($ret);
-
 	return $ret;
 }
 
@@ -138,53 +138,61 @@ function twig_docu($filenames = null)
 			$filenames = array_merge($filenames, twig_dir('pages/'.config_pages.'/widgets', '(.*.\.html)'));
 	}
 	elseif(!is_array($filenames))
-		$filenames = array($filenames);
+		if(twig_isfile($filenames) == false)
+			{
+				$filenames = array($filenames);
+				$filenames = array_merge(twig_dir('dropins/widgets', '(.*.\.html)'));
+			}
+		else
+			$filenames = array($filenames);
+
 
 	$ret = array();
-	
+
 	foreach($filenames as $filename) {
+
 		if(is_array($filename))
 			$filename = const_path.$filename['path'];
-	
 		$file = file_get_contents($filename);
-	
+
+
 		// Header
 		preg_match_all('#.+?@(.+?)\W+(.*)#i', substr($file, 0, strpos($file, '*/') + 2), $header);
 
-		// Body 
+		// Body
 		preg_match_all('#\/\*\*[\r\n]+(.+?)\*\/\s+?\{\% *macro(.+?)\%\}.*?\{\% *endmacro *\%\}#is', strstr($file, '*/'), $widgets);
-	
+
 		if (count($widgets[2]) > 0)
 		{
 			foreach ($widgets[2] as $no => $macro)
 			{
 				$rettmp = array();
-				
+
 				preg_match_all('#(.+?)\((.+?)(\)|,\s+_)#i', $macro, $desc); // param scanning ends on first param name beginning with _
 				$rettmp['name'] = trim($desc[1][0]);
 				$rettmp['params'] = trim($desc[2][0]);
-				
+
 				$docu = $widgets[1][$no];
-	
+
 				$rettmp['desc'] = trim(str_replace('* ', '', substr($docu, 0, strpos($docu, '@'))));
-				
+
 				if (substr($rettmp['desc'], -1, 1) == '*')
 					$rettmp['desc'] = substr($rettmp['desc'], 0, -1);
-				
-				// Header-Tags 
+
+				// Header-Tags
 				foreach ($header[1] as $headerno => $headertag)
 				{
 					if (!($headertag == "author" and trim($header[2][$headerno]) == "Martin Gleiß"))
 						$rettmp[$headertag] = trim($header[2][$headerno]);
 				}
-	
+
 				$rettmp['subpackage'] = substr(strtolower(utf8_decode(basename($filename))), 0, -5);
 				$rettmp['command'] = $rettmp['subpackage'].".".$rettmp['name'];
 				$rettmp['call'] = $rettmp['command']."(".$rettmp['params'].")";
-	
+
 				// Widget-Tags
 				$tags = preg_split('#[\r\n]+[\*\s]*@#', $docu);
-	
+
 				$param = 0;
 				$params = explode(',', $rettmp['params']);
 				$rettmp['param'] = array();
@@ -192,7 +200,7 @@ function twig_docu($filenames = null)
 				foreach ($tags as $tagstring)
 				{
 					preg_match('#^(.+?)\s+({(.+?)(\[\??\])?(\(.*?\))?(=.*?)?}\s+)?(.*)$#is', $tagstring, $tag);
-					 
+
 					if ($tag[1] == 'param')
 					{
 						$p = array('desc' => trim($tag[7]));
@@ -217,7 +225,7 @@ function twig_docu($filenames = null)
 							$p['optional'] = $tag[6] != '';
 							if($p['optional'] && $tag[6] != '=')
 								$p['default'] = substr($tag[6],1);
-							
+
 							// valid_values
 							// array_form must may
 						}
@@ -231,10 +239,10 @@ function twig_docu($filenames = null)
 					else
 						$rettmp[$tag[1]] = trim($tag[7]);
 				}
-	
+
 				$ret[$rettmp['subpackage'].'.'.$rettmp['name']] = $rettmp;
 			}
-	
+
 			//ksort($ret); // as of Version 2.9: Don't sort but use order in sourcefile
 		}
 		else
@@ -246,7 +254,7 @@ function twig_docu($filenames = null)
 			}
 		}
 	}
-	
+
 	return $ret;
 }
 

--- a/pages/docu/custom/widget_custom.html
+++ b/pages/docu/custom/widget_custom.html
@@ -1,0 +1,38 @@
+/**
+* -----------------------------------------------------------------------------
+* @package     smartVISU
+* @author      Onkel Andy
+* @copyright   2020
+* @license     GPL [http://www.gnu.de]
+* -----------------------------------------------------------------------------
+*/
+
+{% extends "widget.html" %}
+
+{% block headline %}
+	<h1>Custom Widgets</h1>
+{% endblock %}
+
+{% block intro %}
+	Some widgets that are not included in the standard smartvisu release.
+	Files in dropins/docu are listed here. Please add this to the top of your HTML file:
+	<div class="twig">
+		<code class="prettyprint">{% filter trim|escape|nl2br %}{% verbatim %}
+	/**
+	* -----------------------------------------------------------------------------
+	* @package     smartVISU
+	* @author      <AUTHORNAME>
+	* @copyright   <YEAR>
+	* @license     GPL [http://www.gnu.de]
+	* -----------------------------------------------------------------------------
+	*/
+	{% endverbatim %}{% endfilter %}</code>
+	</div>
+	as well as
+	<div class="twig">
+		<code class="prettyprint">{% filter trim|escape|nl2br %}{% verbatim %}
+		{% extends "custom/widget_custom.html" %}
+		{% endverbatim %}{% endfilter %}</code>
+	</div>
+
+{% endblock %}

--- a/pages/docu/index.html
+++ b/pages/docu/index.html
@@ -84,6 +84,13 @@
 						<h3>Weather</h3>
 					</a>
 				</li>
+				<li data-icon="false">
+					<a href="index.php?page=custom/widget_custom">
+						<img class="icon" src="{{ icon0 }}edit_settings.svg" alt="Custom" />
+
+						<h3>Custom</h3>
+					</a>
+				</li>
 			</ul>
 		</div>
 
@@ -234,6 +241,7 @@
 	<a href="index.php?page=status/widget_status">Status</a>&nbsp;
 	<a href="index.php?page=clock/widget_clock">Time/Clock</a>&nbsp;
 	<a href="index.php?page=weather/widget_weather">Weather</a>&nbsp;
+	<a href="index.php?page=custom/widget_custom">Custom</a>&nbsp;
 
 	<h2>Design</h2>
 	<a href="index.php?page=design/design_block">Blocks</a>&nbsp;

--- a/pages/docu/widget.html
+++ b/pages/docu/widget.html
@@ -18,7 +18,13 @@
 		{% set widgetlist = docu('widgets/'~pagepath~'.html') %}
 
 		{% for widget in widgetlist %}
+			{% set dir = "pages/docu/%s/widget_%s.html"|format(pagepath, widget.command) %}
+
+			{% if isfile(dir) %}
 			<a href="index.php?page={{ pagepath }}/widget_{{ widget.command }}" {{ widget.deprecated ? 'class="deprecated"' }}>{{ widget.command }}</a>
+			{% elseif widget.command %}
+			<a href="index.php?page=widgets/widget_{{ widget.command }}" {{ widget.deprecated ? 'class="deprecated"' }}>{{ widget.command }}</a>
+		{% endif %}
 		{% endfor %}
 	{% endif %}
 
@@ -40,11 +46,11 @@
 		{% endif %}
 
 			<p>{{ widgetlist[widget].desc }}</p>
-			
+
 			<h5>Parameters</h5>
 
 			<div class="twig">
-				<code>&#123;&#123; {{ widgetlist[widget].call }} &#125;&#125;</code>
+				<code>&#123;&#123;&nbsp;{{ widgetlist[widget].call }}&nbsp;&#125;&#125;</code>
 			</div>
 
 			<div class="param">


### PR DESCRIPTION
It is now possible to include inline documentation plus examples for widget put into dropins/widgets

Files have to be called:
Widget itself including inline docu of parameters:
\<widgetgroup\>.html
\<widgetgroup\>.js

Widget Example:
widget_\<widgetgroup\>.\<macroname\>.html