### PR TITLE
Neuer Treiber für openHAB 2

### DIFF
--- a/driver/io_openhab2.js
+++ b/driver/io_openhab2.js
@@ -1,8 +1,8 @@
 /**
  * -----------------------------------------------------------------------------
  * @package     smartVISU
- * @author      Martin Gleiß
- * @copyright   2012 - 2015
+ * @author      Martin Gleiß, Patrik Germann
+ * @copyright   2012 - 2020
  * @license     GPL [http://www.gnu.de]
  * -----------------------------------------------------------------------------
  * @label       openHAB2
@@ -14,433 +14,305 @@
  */
 var io = {
 
-    // the adress
-    address : '',
-
-    // the port
-    port : '',
+	// the URL
+	url: '',
 
     // the debug switch
-    debug : false,
+    debug: false,
 
-    // -----------------------------------------------------------------------------
-    // P U B L I C F U N C T I O N S
-    // -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
+	// P U B L I C   F U N C T I O N S
+	// -----------------------------------------------------------------------------
 
-    /**
-     * Does a read-request and adds the result to the buffer
-     *
-     * @param the
-     *            item
-     */
-    read : function(item) {
-        io.get(item);
-    },
-
-    /**
-     * Does a write-request with a value
-     *
-     * @param the
-     *            item
-     * @param the
-     *            value
-     */
-    write : function(item, val) {
-        io.put(item, val);
-    },
-
-    /**
-     * Trigger a logic
-     *
-     * @param the
-     *            logic
-     * @param the
-     *            value
-     */
-    trigger : function(name, val) {
-        // not supported
-    },
-
-    /**
-     * Initializion of the driver
-     *
-     * @param the
-     *            ip or url to the system (optional)
-     * @param the
-     *            port on which the connection should be made (optional)
-     */
-    init : function(address, port) {
-        io.address = address;
-        io.port = port;
-        io.stop();
-    },
-
-    /**
-     * Lets the driver work
-     */
-    run : function(realtime) {
-        console.info("Type 'io.debug=true;' to console to see more details.");
-
-        // old items
-        widget.refresh();
-
-        // Get items states. In realtime mode io.all gets called
-        // when the event listener is in place. So no events get lost.
-        if (! realtime)
-            io.all();
-        io.allPlots();
-
-        // run polling
-        if (realtime) {
-            io.start();
-        }
-    },
-
-    // -----------------------------------------------------------------------------
-    // C O M M U N I C A T I O N F U N C T I O N S
-    // -----------------------------------------------------------------------------
-    // The function in this paragraph may be changed. They are all private and
-    // are
-    // only be called from the public functions above. You may add or delete
-    // some
-    // to fit your requirements and your connected system.
-
-    plotItems: Array(),
-
-    /**
-     * Start the real-time values. Can only be started once
-     */
-    start : function() {
-        if (typeof EventSource == 'function') {
-            var me = this;
-            var url = "http://" + io.address + ":" + io.port + "/rest/events?topics=smarthome/items/*/state";
-            var eventSource = new EventSource(url);
-
-            eventSource.addEventListener('message', function(eventPayload) {
-
-                var event = JSON.parse(eventPayload.data);
-
-                if (['ItemStateEvent', 'GroupItemStateChangedEvent'].indexOf(event.type) > -1) {
-                    var payload = JSON.parse(event.payload);
-
-                    var ohItem = event.topic.split('/')[2];
-                    var payloadType = payload.type;
-
-                    var items = io.getItemsFromOHItem(ohItem, payloadType);
-
-                    if(Array.isArray(items)) {
-                        items.forEach(function(item) {
-
-                            var valConverted = io.convertFromOH(item, payload.value);
-                            io.debug && console.info("Update widget item '" + item + "' to value '" + valConverted + "' from state '" + payload.value + "' received for ohab item '" + ohItem + "'.");
-                            widget.update(item, valConverted);
-
-                            // Check if this is a plot item
-                            me.plotItems.forEach(function(plotItem) {
-                                var pt = plotItem.split('.');
-                                if (item === pt[0]) {
-                                    var data = [[new Date().getTime(), parseFloat(valConverted)]];
-                                    io.debug && console.info("Update plot item '" + plotItem + "' by '" + data + "' from state '" + payload.value + "' received for ohab item '" + ohItem + "'.");
-                                    widget.update(plotItem, data);
-                                }
-                            });
-                        });
-
-                        io.debug && items.length === 0 && console.log("Received event for unused ohab item '" + ohItem + "': " + JSON.stringify(event));
-                    }
-
-                }
-            });
-
-            eventSource.addEventListener('open', function(e) {
-                var state = "in unknown (" + this.readyState + ") state";
-
-                switch(this.readyState) {
-                    case EventSource.CONNECTING:
-                        state = "connecting";
-                        break;
-                    case EventSource.OPEN:
-                        state = "open";
-                        break;
-                    case EventSource.CLOSED:
-                        state = "closed";
-                        break;
-                }
-
-                console.info("Stream " + this.url + " is now " + state  + ".");
-
-                io.all();   // update all items to current state
-            });
-
-            eventSource.addEventListener('close', function(e) {
-                console.error("Stream " + this.url + " closed.");
-            });
-        } else {
-            var msg = "Your browser doesn't support EventSource. Cannot connect to ohab SSE API. Item states are polled only once at page load!";
-            console.error(msg);
-            notify.warning("No EventSource support", msg);
-            io.all();
-        }
-    },
-
-    /**
-     * Stop the real-time values
-     */
-    stop : function() {
-    },
-
-    /**
-     * Read a specific item from bus and add it to the buffer
-     */
-    get : function(item) {
-        var url = "http://" + io.address + ":" + io.port + "/rest/items/" + io.getOHItemFromItem(item) + "/state";
-
-        $.ajax({
-            url : url,
+	/**
+	 * Does a read-request and adds the result to the buffer
+	 *
+	 * @param      the item
+	 */
+	read: function (item) {
+		io.debug && console.debug("io.read(item = " + item + ")");
+		
+		$.ajax({
+            url : io.url + 'items/' + item + '/state',
             type : "GET",
             async : true,
             cache : false
-        }).done(function(response) {
-            widget.update(item, response);
-        }).error(notify.json);
-    },
-
-    /**
-     * Write a value to bus
-     */
-    put : function(item, val) {
-        var timer_run = io.timer_run;
-        var url = "http://" + io.address + ":" + io.port + "/rest/items/" + io.getOHItemFromItem(item);
-
-        io.stop();
-        $.ajax({
-            url : url,
-            data : io.convertToOH(item, val),
-            method : "POST",
-            contentType : "text/plain",
-            cache : false
-        }).success(function() {
+		}).done(function(state) {
+			var val = io.convertState(item, state);
+			io.debug && console.debug("io.read: widget.update(item = " + item + ", value = " + val + ")");
             widget.update(item, val);
-            if (timer_run) {
-                io.start();
-            }
+			if (io.plot.listeners[item] && Date.now() - io.plot.items[io.plot.listeners[item]] > io.plot.timer * 1000) {
+				io.plot.refresh(io.plot.listeners[item]);
+			}
         }).error(notify.json);
-    },
+	},
 
-    convertToOH : function(item, val) {
-        var type = io.getTypeFromItem(item);
-        var ohVal = val;
+	/**
+	 * Does a write-request with a value
+	 *
+	 * @param      the item
+	 * @param      the value
+	 */
+	write: function (item, val) {
+		io.debug && console.debug("io.write(item = " + item + ", val = " + val + ")");
 
-        switch (type) {
-        case "Switch":
-            if (val == 0)
-                ohVal = "OFF";
-            else
-                ohVal = "ON";
-            break;
-        case "Contact":
-            if (val == 1)
-                ohVal = "CLOSED";
-            else
-                ohVal = "OPEN";
-            break;
-        }
+		var transval = new Array();
+		switch (io.itemType[item]) {
+			case "Switch":
+				transval[0] = "OFF";
+				transval[1] = "ON";
+			break;
+			case "Contact":
+				transval[0] = "CLOSED";
+				transval[1] = "OPEN";
+			break;
+			case "Dimmer":
+				transval[0] = "OFF";
+				transval[1] = "ON";
+				if (val > 1) {
+					transval[val] = Math.round(val / 255 * 100);
+				}
+			break;
+			case "Rollershutter":
+				transval[0] = "UP";
+				transval[1] = "STOP";
+				transval[255] = "DOWN";
+				if (val > 1 && val < 255) {
+					transval[val] = Math.round(val / 255 * 100);
+				}
+			break;
+			case "Player":
+				transval[0] = "PAUSE";
+				transval[1] = "PLAY";
+				var elementID = false;
+				if ($(event.currentTarget).attr('id')) {
+					elementID = $(event.currentTarget).attr('id');
+				} else if($(event.currentTarget.parentElement).find("span:first-of-type").attr('id')) {
+					elementID = $(event.currentTarget.parentElement).find("span:first-of-type").attr('id');
+				}
+				if (elementID.slice(-4) == 'stop' || elementID.slice(-4) == 'play') {
+					transval[0] = "PAUSE";
+					transval[1] = "PLAY";
+				} else if (elementID.slice(-4) == 'prev' || elementID.slice(-4) == 'next') {
+					transval[0] = "PREVIOUS";
+					transval[1] = "NEXT";
+				} else if (elementID.slice(-3) == 'rew' || elementID.slice(-2) == 'ff') {
+					transval[0] = "REWIND";
+					transval[1] = "FASTFORWARD";
+				}
+			break;
+		default:
+		}
 
-        return ohVal;
-    },
+		var state = (val in transval) ? transval[val] : val;
 
-    convertFromOH : function(item, ohVal) {
-        var type = io.getTypeFromItem(item);
-        var val = ohVal;
+		$.ajax({
+            url			: io.url + 'items/' + item,
+            data		: state.toString(),
+            method		: "POST",
+            contentType	: "text/plain",
+            cache		: false
+		}).success(function() {
+			if (io.refreshIntervall) {
+				widget.update(item, val);
+			}
+		}).error(notify.json);
 
-        switch (type) {
-        case "Switch":
-            if (ohVal == "ON"
-                || Number.parseFloat(ohVal) > 0)
-                val = 1;
-            else
-                val = 0;
-            break;
-        case "Contact":
-            if (ohVal == "CLOSED")
-                val = 1;
-            else if (ohVal == "OPEN")
-                val = 0;
-            break;
-        }
+	},
 
-        return val;
-    },
+	/**
+	 * Trigger a logic
+	 *
+	 * @param      the logic
+	 * @param      the value
+	 */
+	trigger: function (name, val) {
+		io.debug && console.debug("io.trigger(name = " + name + ", val = " + val + ")");
+	},
 
-    getTypeFromItem : function(item) {
-        var itemArray = item.split(":");
+	/**
+	 * Initializion of the driver
+	 *
+	 * @param      the ip or url to the system (optional)
+	 * @param      the port on which the connection should be made (optional)
+	 */
+	init: function (address, port) {
+		io.debug && console.debug("io.init(address = " + address + ", port = " + port + ")");
+		
+		io.url = "http://" + address + (port ? ":" + port : '') + "/rest/";
+	},
 
-        var type = "Unknown";
+	/**
+	 * Lets the driver work
+	 */
+	run: function (realtime) {
+		console.info("Type 'io.debug=true;' to console to see more details.");
+		io.debug && console.debug("io.run(realtime = " + realtime + ")");
+		
+		if (io.eventListener.readyState == 0 || io.eventListener.readyState == 1) {
+			io.eventListener.close();
+		}
+		if (io.refreshIntervall) {
+			clearTimeout(io.refreshIntervall);
+			io.refreshIntervall = false;
+		}
 
-        if (itemArray.length == 2) {
-            type = itemArray[0]
-        }
-
-        // console.log("Determined item type: " + type);
-
-        return type;
-    },
-
-    getOHItemFromItem : function(item) {
-        var itemArray = item.split(":");
-
-        var ohItem = item;
-
-        if (itemArray.length == 2) {
-            ohItem = itemArray[1]
-        }
-
-        // console.log("Determined Openhab item: " + ohItem);
-
-        return ohItem;
-    },
-
-    getHashOfWidgetItems : function() {
-        var widgetItems = widget.listeners();
-
-        return widgetItems.reduce(function (map, value, index, arr) { map[value] = 1; return map; }, {});
-    },
-
-    getItemsFromOHItem : function(ohItem, type, hashOfWidgetItems) {
-        var posItemNames = new Array();
-
-        switch (type) {
-        case "Switch":
-            posItemNames.push("Switch:" + ohItem);
-            break;
-        case "OnOff":
-            posItemNames.push("Switch:" + ohItem);
-            break;
-        case "Contact":
-            posItemNames.push("Contact:" + ohItem);
-            break;
-        case "OpenClosed":
-            posItemNames.push("Contact:" + ohItem);
-            break;
-        case "Dimmer":
-            posItemNames.push(ohItem);
-            posItemNames.push("Switch:" + ohItem);
-            break;
-        case "Rollershutter":
-            posItemNames.push(ohItem);
-            posItemNames.push("Move:" + ohItem);
-            break;
-        case "Percent":
-            posItemNames.push(ohItem);
-            posItemNames.push("Switch:" + ohItem); // Send to widget items of type Switch too. A value > 0 is interpreted as ON, any other value as OFF. Usefull for dimmers.
-        default:
-            posItemNames.push(ohItem);
-        }
-
-        // Now check out which of the possible item names are defined in widgets
-        if(hashOfWidgetItems == null)
-            hashOfWidgetItems = io.getHashOfWidgetItems();
-
-        var items = posItemNames.reduce(function (listOfItems, value, index, arr) { if(hashOfWidgetItems[value]) listOfItems.push(value); return listOfItems; }, []);
-
-        return items;
-    },
-
-    /**
-     * Reads all values from bus and refreshes the pages
-     */
-    all : function() {
-        hashOfWidgetItems = io.getHashOfWidgetItems();
-
-        // only if anyone listens
-        if (Object.keys(hashOfWidgetItems).length > 0) {
-            var url = "http://" + io.address + ":" + io.port + "/rest/items";
-
-            $.ajax({
-                url : url,
-                type : 'GET',
-                dataType : 'json',
-                async : true,
-                cache : false
-            }).done(function(response) {
-                $.each(response, function(index, ohItem) {
-                    var type = ohItem.type;
-                    if(type == "Group")
-                        type = ohItem.groupType;
-
-                    var widgetItems = io.getItemsFromOHItem(ohItem.name, type, hashOfWidgetItems);
-
-                    if(Array.isArray(widgetItems)) {
-                        widgetItems.forEach(function(item) {
-
-                            var valConverted = io.convertFromOH(item, ohItem.state);
-                            io.debug && console.info("Update widget item '" + item + "' to value '" + valConverted + "' from state '" + ohItem.state + "' queried for ohab item '" + ohItem.name + "'.");
-                            widget.update(item, valConverted);
-                        });
-
-                        io.debug && widgetItems.length === 0 && console.log("Queried unused ohab item '" + ohItem.name + "': " + JSON.stringify(ohItem));
-                    }
-                })
-            }).error(notify.json);
-        }
-    },
-
-    allPlots : function() {
-        io.debug && console.info("Updating all plots");
-
-        var me = this;
-
-        var unique = Array();
-
-        widget.plot().each(function(idx) {
-            var items = widget.explode($(this).attr('data-item'));
-            for (var i = 0; i < items.length; i++) {
-
-                var pt = items[i].split('.');
-
-                if (!unique[items[i]] && !widget.get(items[i]) && (pt instanceof Array) && widget.checkseries(items[i])) {
-                    var item = items[i];
-
-                    var ohItem = io.getOHItemFromItem(pt[0]);
-
-                    var duration = new Date().duration(pt[2]);
-
-                    // For OpenHAB it seems to be required to send a date in the correct timezone
-                    // as it seems to ignore the timezone offset
-                    var tzoffset = (new Date()).getTimezoneOffset() * 60000;
-                    var starttime = new Date(new Date() - duration - tzoffset).toISOString().slice(0, -5);
-
-                    var url = "http://" + io.address + ":" + io.port + "/rest/persistence/items/" + ohItem + "?starttime=" + starttime;
-
-                    io.debug && console.info("Updating plot for ohab item '" + ohItem + "' from " + url);
-
-                    $.ajax({
-                        url : url,
-                        type : 'GET',
-                        dataType : 'json',
-                        async : true,
-                        cache : false
-                    }).done(function(response) {
-                        var valArray = [];
-
-                        $.each(response.data, function(index, dataVal) {
-                            valArray.push([ dataVal.time, parseFloat(dataVal.state) ]);
-                        })
-
-                        valArray.sort(function(a, b) {
-                           return a[0] - b[0];
-                        });
-
-                        io.debug && console.log(valArray);
-
-                        widget.update(item, valArray);
-                    }).error(notify.json);
-
-                    unique[items[i]] = 1;
-                    me.plotItems.push(items[i]);
-                }
+        if (widget.listeners().length) {
+            var items = widget.listeners();
+            for (var i = 0; i < widget.listeners().length; i++) {
+				$.ajax({
+					url		: io.url + 'items/' + items[i],
+					type	: "GET",
+					async	: true,
+					cache	: false
+				}).done(function(ohItem) {
+					var item = ohItem.name;
+					io.itemType[item] = ohItem.type;
+					var val = io.convertState(item, ohItem.state);
+					io.debug && console.debug("io.run: widget.update(item = " + item + ", value = " + val + ")");
+					widget.update(item, val);
+				}).error(notify.json);
             }
-        });
-    }
+        }
+		
+        io.plot.init();
 
-};
+		if (realtime) {
+			if (typeof EventSource == 'function') {
+				io.eventListener = new EventSource(io.url + "events?topics=smarthome/items/*/statechanged");
+				io.eventListener.onmessage = function(message) {
+					var event = JSON.parse(message.data);
+					if (event.type === 'ItemStateChangedEvent') {
+						var item = event.topic.split('/')[2];
+						if (widget.listeners().includes(item)) {
+							var val = io.convertState(item, JSON.parse(event.payload).value);
+							io.debug && console.debug("io.start.event: widget.update(item = " + item + ", value = " + val + ")");
+							widget.update(item, val);
+						}
+						if (io.plot.listeners[item] && Date.now() - io.plot.items[io.plot.listeners[item]] > io.plot.timer * 1000) {
+							io.plot.refresh(io.plot.listeners[item]);
+						}
+					}
+				}
+			} else {
+				if (!io.refreshIntervall && widget.listeners().length) {
+					io.refreshIntervall = setInterval(function() {
+						var item = widget.listeners();
+						for (var i = 0; i < widget.listeners().length; i++) {
+							io.read(item[i]);
+						}
+					}, io.timer * 1000);
+				}
+			}
+		}
+	},
+
+
+	// -----------------------------------------------------------------------------
+	// C O M M U N I C A T I O N   F U N C T I O N S
+	// -----------------------------------------------------------------------------
+	// The functions in this paragraph may be changed. They are all private and are
+	// only be called from the public functions above. You may add or delete some
+	// to fit your requirements and your connected system.
+
+	itemType: new Array(),
+	eventListener: false,
+	refreshIntervall: false,
+	timer: 1,
+
+	convertState: function (item, state) {
+		io.debug && console.debug("io.convertState(item = " + item + ", state = " + state + ")");
+		
+		var transval = {
+			"NULL"	: 0,
+			"OFF"	: 0, "ON"			: 1,
+			"CLOSED": 0, "OPEN"			: 1,
+			"PAUSE"	: 0, "PLAY"			: 1,
+			"REWIND": 0, "FASTFORWARD"	: 1
+		}
+
+		switch (io.itemType[item]) {
+			case "Color":
+				return state == "NULL" ? "0,0,0" : state;
+			case "Dimmer":
+			case "Rollershutter":
+				return Math.round((state in transval) ? transval[state] : state / 100 * 255);
+			default:
+				return (state in transval) ? transval[state] : state;
+		}
+	},
+
+	plot: {
+		items: new Array(),
+		listeners: new Array(),
+		timer: 10,
+		
+		init: function() {
+			io.debug && console.debug("io.plot.init()");
+			
+			io.plot.listeners = new Array();
+			widget.plot().each(function(idx) {
+				var items = widget.explode($(this).attr('data-item'));
+				for (var i = 0; i < items.length; i++) {
+					var plotItem = items[i];
+					var pt = plotItem.split('.');
+					if (!io.plot.items[plotItem] && (pt instanceof Array) && widget.checkseries(plotItem)) {
+						if (pt[3] == 'now') {
+							io.plot.listeners[pt[0]] = plotItem;
+						}
+						io.plot.refresh(plotItem);
+						io.plot.items[plotItem] = true;
+					}
+				}
+			});
+		},
+
+		refresh: function(plotItem) {
+			io.debug && console.debug("io.plot.refresh(plotItem = " + plotItem + ")");
+			
+			var pt = plotItem.split('.');
+			var item = pt[0];
+			var tmin = new Date().duration(pt[2]);
+			var tmax = pt[3];
+		
+			var starttime = new Date(Date.now() - tmin);
+			var url = io.url + "persistence/items/" + item + "?starttime=" + starttime.toISOString();
+			
+			if (tmax != 'now') {
+				tmax = new Date().duration(pt[3]);
+				var endtime = new Date(new Date() - tmax);
+				url += "&endtime=" + endtime.toISOString();
+			}
+
+			$.ajax({
+				url : url,
+				type : 'GET',
+				dataType : 'json',
+				async : false,
+				cache : false
+			}).done(function(persistence) {
+				var plotData = new Array();
+				if (persistence.data.length > 0) {
+					$.each(persistence.data, function(key, data) {
+						var val = io.convertState(item, data.state);
+						if (isNaN(val)) {
+							val = 0;
+						} else if (Number(val) == val && val % 1 !== 0) { //isFloat
+							val = parseFloat(val).toFixed(2);
+						}
+						plotData.push([data.time, parseFloat(val)]);
+					})
+					plotData.sort(function(a, b) {
+						return a[0] - b[0];
+					});
+				} else {
+					plotData.push([Date.parse(starttime), 0]);
+					plotData.push([endtime ? Date.parse(endtime) : Date.now(), 0])
+				}
+				io.plot.items[plotItem] = Date.now();
+				io.debug && console.debug("io.plot.refresh: widget.update(plotItem = " + plotItem + ", plotData = " + plotData + ")");
+				widget.update(plotItem, plotData);
+			}).error(notify.json);
+		}
+	}
+}


### PR DESCRIPTION
Unterstützt alle Widgets, Devices und Plots von smartVISU 2.9 und alle Items aus openHAB 2, außer Player und Multimedia-Widgets, ohne besondere Notationen.
Nur folgende Itemangaben müssen, abweichend zur Doku, eingehalten werden:
 - basic.color: Das openHAB2-Coloritem darf nur bei item_r_h angegeben werden, alle anderen Items müssen leer bleibenund das Colormodel muss 'hsv' sein.
 - device.blind: Das openHAB2-Rollershutteritem darf nur bei item_pos angegeben werden und, wenn man auch einen Stop-Button haben möchte, zusätzlich bei item_stop. Alle anderen Items müssen leerbleiben.

Wenn der Browser EventListeners unterstützt, werden aktuelle Widgets in Echtzeit aktualisiert, ansonsten jede Sekunde neu abgefragt. Existiert ein Plot mit tmax = now und das betreffende Item wird aktualisiert, so wird auch der Plot aktualisiert, sofern die letzte Aktualisierung länger als eine Minute her ist.

Die Rollershutterposition und Dimmervalues kommen von openHAB 2 in Prozentangaben (0 - 100) und werden durch den Treiber in Werte (0 - 255) umgewandelt. Somit entfällt auch die Angabe von min und max bei den Widgets, wenn man den vollen Bereich benutzen möchte.