### PR TITLE
configcheck and  replace rename() with copy() & unlink() about windows

### DIFF
--- a/lib/base/check_config.php
+++ b/lib/base/check_config.php
@@ -22,7 +22,7 @@ if ((!is_file(const_path.'config.ini') && is_writeable(const_path)) || (is_file(
 else
 {
 	header("HTTP/1.0 600 smartVISU Config Error");
-	$ret = array('icon' => 'message_attention.svg', 'text' => "'".const_path."config.ini' file can't be created!");
+	$ret = array('icon' => 'message_attention.svg', 'text' => "'".const_path."config.ini' file isn't writable or can't be created!");
 }
 
 echo json_encode($ret);

--- a/lib/base/check_config.php
+++ b/lib/base/check_config.php
@@ -15,7 +15,7 @@ require_once '../../lib/includes.php';
 // init parameters
 $request = array_merge($_GET, $_POST);
 
-if (is_writeable(const_path) && (!is_file(const_path.'config.ini') || is_writeable(const_path.'config.ini')))
+if ((!is_file(const_path.'config.ini') && is_writeable(const_path)) || (is_file(const_path.'config.ini') && is_writeable(const_path.'config.ini')))
 {
 	$ret = array('icon' => 'message_ok.svg', 'text' => "'config.ini' file can be created");
 }

--- a/lib/base/check_config.php
+++ b/lib/base/check_config.php
@@ -17,7 +17,7 @@ $request = array_merge($_GET, $_POST);
 
 if ((!is_file(const_path.'config.ini') && is_writeable(const_path)) || (is_file(const_path.'config.ini') && is_writeable(const_path.'config.ini')))
 {
-	$ret = array('icon' => 'message_ok.svg', 'text' => "'config.ini' file can be created");
+	$ret = array('icon' => 'message_ok.svg', 'text' => "'config.ini' file is writable or can be created");
 }
 else
 {

--- a/lib/base/check_config.php
+++ b/lib/base/check_config.php
@@ -17,12 +17,12 @@ $request = array_merge($_GET, $_POST);
 
 if ((!is_file(const_path.'config.ini') && is_writeable(const_path)) || (is_file(const_path.'config.ini') && is_writeable(const_path.'config.ini')))
 {
-	$ret = array('icon' => 'message_ok.svg', 'text' => "'config.ini' file is writable or can be created");
+	$ret = array('icon' => 'message_ok.svg', 'text' => "'config.ini' file is writeable or can be created");
 }
 else
 {
 	header("HTTP/1.0 600 smartVISU Config Error");
-	$ret = array('icon' => 'message_attention.svg', 'text' => "'".const_path."config.ini' file isn't writable or can't be created!");
+	$ret = array('icon' => 'message_attention.svg', 'text' => "'".const_path."config.ini' file isn't writeable or can't be created!");
 }
 
 echo json_encode($ret);

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -223,7 +223,8 @@ function filewrite($file, $ret)
 		@chown($tmpFile, $stat['uid']);
 		@chgrp($tmpFile, $stat['gid']);
 	}
-	rename($tmpFile, $file);
+	copy($tmpFile, $file);
+	unlink($tmpFile);
 
 	return $ret;
 }
@@ -291,7 +292,8 @@ function write_ini_file($assoc_arr, $path, $has_sections=FALSE) {
 			@chown($tmpFile, $stat['uid']);
 			@chgrp($tmpFile, $stat['gid']);
 		}
-		$success &= rename($tmpFile, $path);
+		$success &= copy($tmpFile, $path);
+		unlink($tmpFile);
 	}
 
 	return $success;


### PR DESCRIPTION
Die Beschreibbarkeit des Configverzeichnis wird nur geprüft, wenn die Configdatei nicht existiert und erstellt werden muss.

Der PHP-Befehl rename() funktioniert unter Windows verzeichnisübergreifend nicht korrekt und wurde durch copy() und unlink() ersetzt.