### PR TITLE
fix auto-reconnect after frozen tab

### DIFF
--- a/lib/base/base.js
+++ b/lib/base/base.js
@@ -105,10 +105,6 @@ function activateAutoReconnect(address, port) {
 				io.init(address, port);
 			}
 		}, 5000);
-
-		window.onbeforeunload = function() {
-			window.clearInterval(autoReconnectIntervalId);
-		};
 	}
 }
 


### PR DESCRIPTION
Solves the following problem on the Smartphone: After the tab/window ran in the background for a while, SmartVisu is no longer connected to the web socket and I have to reload the page.

Reactivate auto-reconnect interval after the window was frozen/hidden on mobile browsers.

I think it is not necessary to delete the timers in onBeforeUnload, because they will be deleted anyway when closing the tab/window.