### PR TITLE
terminate old widget support & correct item sequence

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -57,6 +57,8 @@
 ### Removed Features
 - deprecated widgets from v2.8 and earlier have been deleted
 - removed protocol versions <= 3 in smarthome.py driver
+- support for older widgets (non jQuery mobile types) has been terminated 
+  (in case of urgency re-activateable in ./lib/base/base.js by uncommenting widget.update, widget.prepare, widget.refresh)
 
 ### Fixed Bugs
 - error thrown if default calender icons in language files were missing
@@ -66,6 +68,7 @@
 - fixed device.rtr misleading night / day icons 
 - all examples and docu checked and optimized with template checker
 - calendar.waste entries got overruled by smaller snippets (e.g. "green bin" by "bin" ) if snippet was not listed first 
+- widget.explode() was sorting purely numeric item names, so occationally items were swapped
 
 
 ## 2.9.2

--- a/lib/base/base.js
+++ b/lib/base/base.js
@@ -100,6 +100,7 @@ function printf(format, val) {
 function activateAutoReconnect(address, port) {
 	if(io.socket) {
 		var autoReconnectIntervalId = window.setInterval(function () {
+			// console.log('checking if websocket is alive: state = '+ io.socket.readyState);
 			if(io.socket.readyState == 3) {
 				console.log("WebSocket closed, reconnect...");
 				io.init(address, port);
@@ -107,9 +108,10 @@ function activateAutoReconnect(address, port) {
 		}, 5000);
 
 		// clear interval removed after pr#353 to fix reconnect after frozen tab 		
-		//window.onbeforeunload = function() {
-		//	window.clearInterval(autoReconnectIntervalId);
-		//};
+		window.onbeforeunload = function() {
+		console.log('event onbeforeunload');
+		window.clearInterval(autoReconnectIntervalId);
+		};
 	}
 }
 
@@ -1364,21 +1366,15 @@ var widget = {
 	 */
 	explode: function (text) {
 		var ret = Array();
-		var unique = Array();
-
+		
 		// More than one item?
 		if (text.indexOf(',') >= 0) {
 			var parts = text.explode();
 
 			for (var i = 0; i < parts.length; i++) {
-				if (parts[i] != '') {
-					unique[parts[i]] = '';
-				}
+				if(!ret.includes(parts[i]) && parts[i] != '' )	ret.push(parts[i]);	
 			}
 
-			for (var part in unique) {
-				ret.push(part);
-			}
 		}
 
 		// One item
@@ -1514,39 +1510,40 @@ var widget = {
 		if (value === undefined || widget.buffer[item] === undefined || widget.buffer[item] !== value && !(widget.buffer[item] instanceof Array && widget.buffer[item].equals(value))) {
 
 			widget.set(item, value);
-
+			
 			$(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-item*="' + item + '"]').filter(':data("sv-widget")').widget('update', widget.get(item), item) // new jQuery Mobile style widgets
-			.invert().each(function (idx) { // Old-style widgets, DEPRECATED as of 2.9
+			
+			//.invert().each(function (idx) { // Old-style widgets, DEPRECATED as of 2.9
 
-				console.warn('Plain old smartVISU widgets are deprecated. Use a jQuery widget based on $.sv.widget instead.', this);
+			//	console.warn('Plain old smartVISU widgets are deprecated. Use a jQuery widget based on $.sv.widget instead.', this);
 
-				var items = widget.explode($(this).attr('data-item'));
+			//	var items = widget.explode($(this).attr('data-item'));
 
 				// update to a plot: only add a point
-				if ($(this).attr('data-widget').substr(0, 5) == 'plot.' && $(this).highcharts()) { // alternative: jQuery._data( this, "events" )['point'] !== undefined;
-					if (value !== undefined) {
-						var values = [];
+			//	if ($(this).attr('data-widget').substr(0, 5) == 'plot.' && $(this).highcharts()) { // alternative: jQuery._data( this, "events" )['point'] !== undefined;
+			//		if (value !== undefined) {
+			//			var values = [];
 						// if more than one item, only that with the value
-						for (var j = 0; j < items.length; j++) {
-							values.push(items[j] == item ? value : null);
-						}
+			//			for (var j = 0; j < items.length; j++) {
+			//				values.push(items[j] == item ? value : null);
+			//			}
 						// DEBUG:
-						console.log("[" + $(this).attr('data-widget') + "] point '" + this.id + "':", values);
-						$(this).trigger('point', [values]);
-					}
-				}
+			//			console.log("[" + $(this).attr('data-widget') + "] point '" + this.id + "':", values);
+			//			$(this).trigger('point', [values]);
+			//		}
+			//	}
 
 				// regular update to the widget with all items
-				else {
-					values = widget.get(items);
-					if (widget.check(values)) {
+			//	else {
+			//		values = widget.get(items);
+			//		if (widget.check(values)) {
 						// DEBUG:
-						console.log("[" + $(this).attr('data-widget') + "] update '" + this.id + "':", values);
-						$(this).trigger('update', [values]);
-					}
-				}
+			//			console.log("[" + $(this).attr('data-widget') + "] update '" + this.id + "':", values);
+			//			$(this).trigger('update', [values]);
+			//		}
+			//	}
 
-			});
+			//});
 		}
 	},
 
@@ -1557,13 +1554,13 @@ var widget = {
 	 * DEPRECATED as of 2.9
 	 */
 	prepare: function () {
-		// all plots on the current page.
-		$(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-widget^="plot."][data-item]:not(:data("sv-widget"))').each(function (idx) {
-			console.warn('Plain old smartVISU widgets are deprecated. Use a jQuery widget based on $.sv.widget instead.', this);
-			if ($(this).highcharts()) {
-				$(this).highcharts().destroy();
-			}
-		});
+//		// all plots on the current page.
+//		$(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-widget^="plot."][data-item]:not(:data("sv-widget"))').each(function (idx) {
+//			console.warn('Plain old smartVISU widgets are deprecated. Use a jQuery widget based on $.sv.widget instead.', this);
+//			if ($(this).highcharts()) {
+//				$(this).highcharts().destroy();
+//			}
+//		});
 	},
 
 	/**
@@ -1572,19 +1569,20 @@ var widget = {
 	 */
 	refresh: function () {
 		$(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-item]').filter(':data("sv-widget")').widget('update') // new jQuery Mobile style widgets
-			.invert().each(function (idx) { // Old-style widgets, DEPRECATED as of 2.9
-			console.warn('Plain old smartVISU widgets are deprecated. Use a jQuery widget based on $.sv.widget instead.', this);
-
-			var values = widget.get(widget.explode($(this).attr('data-item')));
-
-			if (widget.check(values)) {
-				$(this).trigger('update', [values]);
-				console.log("[" + $(this).attr('data-widget') + "] update '" + this.id + "':", values);
-			}
-		});
+//			.invert().each(function (idx) { // Old-style widgets, DEPRECATED as of 2.9
+//			console.warn('Plain old smartVISU widgets are deprecated. Use a jQuery widget based on $.sv.widget instead.', this);
+//
+//			var values = widget.get(widget.explode($(this).attr('data-item')));
+//
+//			if (widget.check(values)) {
+//				$(this).trigger('update', [values]);
+//				console.log("[" + $(this).attr('data-widget') + "] update '" + this.id + "':", values);
+//			}
+//		});
 
 		//TODO: call io.run here instead of this in io.run and io.run in root.html
-
+		// config_driver_realtime needs to be evaluated
+		
 		//widget.getUrlData();
 	},
 
@@ -1798,7 +1796,7 @@ $(document).on("pagebeforeload", function(event, data) {
 
 /** 
  * stop series subscriptions and trigger 'exit' method in all widgets on current page
- * before new page is being loaded  
+ * before new page is being loaded 
  * pagecontainerbeforechange event is triggered twice but with different attributes
  * at first occurrence ui.toPage only contains the URL of target pages as a string
  */
@@ -1837,7 +1835,7 @@ $.widget( "ui.tabs", $.ui.tabs, {
 
 /**
  * -----------------------------------------------------------------------------
- * C O F I G U R A T I O N   P A G E
+ * C O N F I G U R A T I O N   P A G E
  * -----------------------------------------------------------------------------
  */
 function changeDisabledState(parent, disable) {
@@ -2039,7 +2037,11 @@ $(document).on('pagecreate', function (event, ui) {
 	}
 });
 
-
+/**
+ * -----------------------------------------------------------------------------
+ * P R O T O T Y P E   F O R   S V . W I D G E T S
+ * -----------------------------------------------------------------------------
+ */
 $.widget("sv.widget", {
 	options: {
 		id: null,
@@ -2115,9 +2117,9 @@ $.widget("sv.widget", {
 	
 /**
  * Check if exit function exists in the widget and run it
- */	
+ */
 	exit: function(){
 		if (this._exit) this._exit();
 	}
-	
+
 });


### PR DESCRIPTION
terminate non jQuery mobile widget support.
This can be re-activated by uncommenting lines in ./lib/base/base.js in widget.update, widget.prepare and widget.refresh

Correct issue #437 which caused sequence errors with purely numeric item names.