### PR TITLE
Erweiterung für Treiberauthentifizierung und SSL für openHAB3

### DIFF
--- a/driver/_io_template.js
+++ b/driver/_io_template.js
@@ -60,7 +60,7 @@ var io = {
 	 * @param      the ip or url to the system (optional)
 	 * @param      the port on which the connection should be made (optional)
 	 */
-	init: function (address, port) {
+	init: function (address, port, ssl, username, password) {
 		io.address = address;
 		io.port = port;
 

--- a/driver/hints_openHAB.md
+++ b/driver/hints_openHAB.md
@@ -1,15 +1,15 @@
-Hinweise zum neuen openHAB 2 driver:
+Hinweise zum neuen openHAB Treiber:
 
-Der Treiber unterstützt alle Widgets, Devices und Plots von smartVISU 2.9 und alle Items aus openHAB 2 (getestet mit 2.5.x), außer Player und den dazugehörigen Multimedia-Widgets, ohne besondere Notationen. Nur folgende Itemangaben müssen, abweichend zur Doku, eingehalten werden:
-- basic.color: Das openHAB2-Coloritem darf nur bei item_r_h angegeben werden. Alle anderen Itemangaben müssen leer bleiben und das Colormodel muss 'hsv' sein.
-- device.blind: Das openHAB2-Rollershutteritem darf nur bei item_pos angegeben werden und, wenn man auch einen Stop-Button haben möchte, zusätzlich als item_stop. Alle anderen Itemangaben müssen leer bleiben.
+Der Treiber unterstützt alle Widgets, Devices und Plots von smartVISU und alle Items aus openHAB, außer Player und den dazugehörigen Multimedia-Widgets, ohne besondere Notationen. Nur folgende Itemangaben müssen, abweichend zur Doku, eingehalten werden:
+- basic.color: Das openHAB-Coloritem darf nur bei item_r_h angegeben werden. Alle anderen Itemangaben müssen leer bleiben und das Colormodel muss 'hsv' sein.
+- device.blind: Das openHAB-Rollershutteritem darf nur bei item_pos angegeben werden und, wenn man auch einen Stop-Button haben möchte, zusätzlich als item_stop. Alle anderen Itemangaben müssen leer bleiben.
 
 
 Die Rollershutterposition und Dimmervalues (DPT 5.001) kommen von openHAB 2 in Prozentangaben (0 - 100). Dadurch muss in den Widgets bei 'max' 100 angegeben werden, z. Bsp.:
 - {{ device.blind('', '', '', 'RollershutterItem', 'RollershutterItem', '', '', 0, 100, 1) }}
 - {{ device.dimmer('', '', 'DimmerItem', 'DimmerItem', 0, 100, 1) }}
 
-Wenn man Prozentwerte (DPT 5.001) auch anderweitig verwenden möchte/muss, z. Bsp. für Luftfeuchte, dann muss man in openHAB2 dafür ein Item mit Type "Dimmer" verwenden. Der Type des verlinkten KNX-Thingchannel kann trotzdem "Number" sein, es muss aber der DPT 5.001 (5.001:<1/2/3) angegeben werden. Nur so kommen von openHAB auch verwendbare Prozentangaben (0 - 100). Verwendet man ein Item mit Type Number kommen von openHAB kalkulatorische Prozentwerte im Bereich 0.00 bis 1.00. 
+Wenn man Prozentwerte (DPT 5.001) auch anderweitig verwenden möchte/muss, z. Bsp. für Luftfeuchte, dann muss man in openHAB dafür ein Item mit Type "Dimmer" verwenden. Der Type des verlinkten KNX-Thingchannel kann trotzdem "Number" sein, es muss aber der DPT 5.001 (5.001:<1/2/3) angegeben werden. Nur so kommen von openHAB auch verwendbare Prozentangaben (0 - 100). Verwendet man ein Item mit Type Number kommen von openHAB kalkulatorische Prozentwerte im Bereich 0.00 bis 1.00. 
 
 
-Sofern der Browser EventListeners unterstützt, werden aktuelle Widgets in Echtzeit aktualisiert, ansonsten jede Sekunde neu abgefragt. Existiert ein Plot ohne Endzeitpunkt (tmax = 'now') und das betreffende Item wird aktualisiert, so wird auch der Plot aktualisiert, sofern die letzte Aktualisierung länger als 10 Sekunden her ist, um Daueraktualisierungen von Plots bei schnellen Wertveränderungen zu vermeiden.
+Wenn der Treiber ohne Authentifizierung genutzt wird und der Browser EventListeners unterstützt, werden aktuelle Widgets in Echtzeit aktualisiert, ansonsten jede Sekunde neu abgefragt. Existiert ein Plot ohne Endzeitpunkt (tmax = 'now') und das betreffende Item wird aktualisiert, so wird auch der Plot aktualisiert, sofern die letzte Aktualisierung länger als 10 Sekunden zurück liegt, um Daueraktualisierungen von Plots bei schnellen Wertveränderungen zu vermeiden.

--- a/driver/io_eibd.js
+++ b/driver/io_eibd.js
@@ -9,6 +9,8 @@
  * @label       knxd / eibd
  * @hide        driver_autoreconnect
  * @hide		reverseproxy
+ * @hide		driver_username
+ * @hide		driver_password
  */
 
 
@@ -64,7 +66,7 @@ var io = {
 	 * @param      the ip or url to the system (optional)
 	 * @param      the port on which the connection should be made (optional)
 	 */
-	init: function (address, port) {
+	init: function (address, port, ssl, username, password) {
 		io.address = address;
 		io.port = port;
 		io.stop();

--- a/driver/io_fhem.js
+++ b/driver/io_fhem.js
@@ -9,6 +9,8 @@
  * @label       FHEM
  * @hide        driver_autoreconnect
  * @hide		reverseproxy
+ * @hide		driver_username
+ * @hide		driver_password
  * @default     driver_port 2121
  *
  * This driver has enhancements for using smartVISU with FHEM
@@ -75,7 +77,7 @@ var io = {
   // -----------------------------------------------------------------------------
   // Initialization of the driver
   // -----------------------------------------------------------------------------
-  init: function(address, port) {
+  init: function (address, port, ssl, username, password) {
     io.log(0, "init (address=" + address + " port=" + port + ")");
     io.address = address;
     io.port = port;

--- a/driver/io_iobroker.js
+++ b/driver/io_iobroker.js
@@ -11,6 +11,8 @@
  * @default     driver_port            8084
  * @hide        driver_realtime
  * @hide		reverseproxy
+ * @hide		driver_username
+ * @hide		driver_password
  */
 
 /**
@@ -82,7 +84,7 @@ var io = {
 	 * @param		the ip or url to the system (optional)
 	 * @param		the port on which the connection should be made (optional)
 	 */
-	init: function (address, port) {
+	init: function (address, port, ssl, username, password) {
 		io.address = address;
 		io.port = port;
 		

--- a/driver/io_json.js
+++ b/driver/io_json.js
@@ -8,6 +8,8 @@
  * @label       JSON
  * @hide        driver_autoreconnect
  * @hide		reverseproxy
+ * @hide		driver_username
+ * @hide		driver_password
  */
 
 
@@ -63,7 +65,7 @@ var io = {
 	 * @param      the ip or url of the system (optional)
 	 * @param      the port on which the connection should be made (optional)
 	 */
-	init: function (address, port) {
+	init: function (address, port, ssl, username, password) {
 		io.address = address;
 		io.port = port;
 		io.stop();

--- a/driver/io_linknx.js
+++ b/driver/io_linknx.js
@@ -8,6 +8,8 @@
  * @default     driver_port            1028
  * @hide        driver_autoreconnect
  * @hide		reverseproxy
+ * @hide		driver_username
+ * @hide		driver_password
  */
 
 
@@ -63,7 +65,7 @@ var io = {
 	 * @param      the ip or url to the system (optional)
 	 * @param      the port on which the connection should be made (optional)
 	 */
-	init: function (address, port) {
+	init: function (address, port, ssl, username, password) {
 		io.address = address;
 		io.port = port;
 		io.stop();

--- a/driver/io_offline.js
+++ b/driver/io_offline.js
@@ -9,6 +9,8 @@
  * @hide        driver_port
  * @hide        driver_autoreconnect
  * @hide		reverseproxy
+ * @hide		driver_username
+ * @hide		driver_password
  */
 
 
@@ -65,7 +67,7 @@ var io = {
 	 * @param      the ip or url to the system (optional)
 	 * @param      the port on which the connection should be made (optional)
 	 */
-	init: function (address, port) {
+	init: function (address, port, ssl, username, password) {
 		io.address = address;
 		io.port = port;
 		io.stop();

--- a/driver/io_smarthome.py.js
+++ b/driver/io_smarthome.py.js
@@ -11,6 +11,8 @@
  * @default     driver_port            2424
  * @default	    reverseproxy           false
  * @hide        driver_realtime
+ * @hide		driver_username
+ * @hide		driver_password
  */
 
 
@@ -67,7 +69,7 @@ var io = {
 	 * @param      the ip or url to the system (optional)
 	 * @param      the port on which the connection should be made (optional)
 	 */
-	init: function (address, port) {
+	init: function (address, port, ssl, username, password) {
 		io.address = address;
 		io.port = port;
 		io.open();

--- a/lang/de.ini
+++ b/lang/de.ini
@@ -419,6 +419,14 @@ driver_autoreconnect[hint] = "Soll die Verbindung nach einem Abbruch automatisch
 reverseproxy[label] = "Rev. Proxy"
 reverseproxy[hint] = "Wenn der Server als Reverse Proxy konfiguriert ist, bleiben die Felder IP-Adresse und Port leer"
 
+auth-security[label] = "Authentifizierung/Sicherheit"
+driver_username[label] = "Benutzername"
+driver_username[hint] = "Der Benutzername oder API-Token für die Authentifizierung am Server."
+driver_password[label] = "Kennwort"
+driver_password[hint] = "Das Kennwort zum Benutzernamen. Bei Verwenung eines API-Tokens meist leer." PHP_EOL "ACHTUNG: Das Kennwort wird unverschlüsselt in der config.ini gespeichert und wenn SSL nicht aktiviert ist auch unverschlüsselt zum Server übertragen."
+driver_ssl[label] = "SSL"
+driver_ssl[hint] = "Zur verschlüsselten Kommunikation mit dem Server aktivieren. Bei Verwendung der Authentifizierung mit Kennwort empfohlen." PHP_EOL "ACHTUNG: Das Zertifikat des Servers muss am Client vertrauenswürdig sein, sonst wird die Verbindung abgelehnt."
+
 proxyserver[label] = "Proxy-Server"
 proxy[label] = "Proxy"
 proxy[hint] = "Diese Einstellung aktivieren, wenn die Internetverbindung des smartVISU-Servers über einen Proxyserver läuft."

--- a/lang/en.ini
+++ b/lang/en.ini
@@ -407,6 +407,14 @@ driver_autoreconnect[hint] = "Automatically reconnect in case of a connection dr
 reverseproxy[label] = "Rev. Proxy"
 reverseproxy[hint] = "If the server is configured as reverse proxy the fields for IP address and port must be empty"
 
+auth-security[label] = "Authentication/Security"
+driver_username[label] = "Username"
+driver_username[hint] = "The username or API token for authentication on the server. "
+driver_password[label] = "Password"
+driver_password[hint] = "The password for the username. Usually empty when using an API token. " PHP_EOL " ATTENTION: The password is saved unencrypted in config.ini and if SSL is not activated it is also transmitted unencrypted to the server. "
+driver_ssl[label] = "SSL"
+driver_ssl[hint] = "Activate for encrypted communication with the server and, if necessary, adjust the port settings to the SSL port, if different from 443. "PHP_EOL" Recommended when using authentication with a password. "PHP_EOL" ATTENTION: The server's certificate must be trustworthy on the client, otherwise the connection is refused."
+
 proxyserver[label] = "Proxy Server"
 proxy[label] = "Proxy"
 proxy[hint] = "Activate this setting if the smartVISU server is connecting to the Internet through a proxy server."

--- a/lib/base/base.js
+++ b/lib/base/base.js
@@ -97,13 +97,13 @@ function printf(format, val) {
 /**
  * Activates check and reload for lost WebSocket connection
  */
-function activateAutoReconnect(address, port) {
+function activateAutoReconnect(address, port, ssl, username, password) {
 	if(io.socket) {
 		var autoReconnectIntervalId = window.setInterval(function () {
 			// console.log('checking if websocket is alive: state = '+ io.socket.readyState);
 			if(io.socket != null && io.socket.readyState == 3) {
 				console.log("WebSocket closed, reconnect...");
-				io.init(address, port);
+				io.init(address, port, ssl, username, password);
 			}
 		}, 5000);
 

--- a/pages/base/config.html
+++ b/pages/base/config.html
@@ -92,6 +92,12 @@
 								
 							</div>
 							<div data-role="collapsible" data-collapsed="true" data-theme="c" data-content-theme="a" >
+								<h3>{{ lang('configuration_page', 'auth-security', 'label') }}</h3>
+								{{ forms.config_flip(source, values, 'driver_ssl') }}
+								{{ forms.config_input(source, values, 'driver_username', 'wide') }}
+								{{ forms.config_input(source, values, 'driver_password', 'wide') }}
+							</div>
+							<div data-role="collapsible" data-collapsed="true" data-theme="c" data-content-theme="a" >
 								<h3>{{ lang('configuration_page', 'proxyserver', 'label') }}</h3>
 								{{ forms.config_flip(source, values, 'proxy') }}
 								{{ forms.config_input(source, values, 'proxy_url', 'wide') }}

--- a/pages/base/root.html
+++ b/pages/base/root.html
@@ -185,9 +185,9 @@
 {% block head %}{% endblock %}
 
 <script>
-	io.init('{{ config_driver_address }}', '{{ config_driver_port }}');
+	io.init('{{ config_driver_address }}', '{{ config_driver_port }}', '{{ config_driver_ssl }}', '{{ config_driver_username }}', '{{ config_driver_password }}');
 {% if config_driver_autoreconnect %}
-	activateAutoReconnect('{{ config_driver_address }}', '{{ config_driver_port }}');
+	activateAutoReconnect('{{ config_driver_address }}', '{{ config_driver_port }}', '{{ config_driver_ssl }}', '{{ config_driver_username }}', '{{ config_driver_password }}');
 {% endif %}
 
 {% if config_backtohometime > 0 %}


### PR DESCRIPTION
Der openHAB2-Treiber ist nur noch aus kompatibilitätsgründen enthalten und kann auch genauso gut gelöscht werden.

Eventuell sollte man die Bereitstellung der (Treiber-)Konfiguration generell überdenken und nicht über io.init() als Parameter übergeben, sondern vielleicht als globale Konstanten zur Verfügung stellen. Ebenso sollte man vielleicht überdenken, dass man die Treiberkonfigurationsoptionen der einzelnen Treiber nicht über die Metadaten ausblendet, sondern welche die benötigt werden einblendet (show, statt hide). Dann kann jeder Treiber für sich einstellen was benötigt wird und muss nicht beim Benötigt werden einer einzelnen Treiberkonfigurationsoption  alle anderen Treiber zusätzlich anpassen.