### PR TITLE
Eventhandler: Anpassung Namespace

### DIFF
--- a/driver/io_openhab.js
+++ b/driver/io_openhab.js
@@ -166,11 +166,7 @@ var io = {
 		if (realtime) {
 
 			if (typeof EventSource == 'function' && io.auth === false) {
-				var OHnamespace = "openhab";
-				if (io.getOHversion() < 3) {
-					OHnamespace = "smarthome";
-				}
-				var eventurl = io.url + "events?topics=" + OHnamespace + "/items/*/statechanged";
+				var eventurl = io.url + "events?topics=" + (io.getOHversion() < 3 ? "smarthome" : "openhab") + "/items/*/statechanged";
 				io.debug && console.debug("io.run: eventListener(" + eventurl + ")");
 				io.eventListener = new EventSource(eventurl);
 				io.eventListener.onmessage = function(message) {

--- a/driver/io_openhab.js
+++ b/driver/io_openhab.js
@@ -24,7 +24,7 @@ var io = {
 	url: '',
 
 	// the debug switch
-	debug: true,
+	debug: false,
 
 	// -----------------------------------------------------------------------------
 	// P U B L I C   F U N C T I O N S
@@ -115,7 +115,7 @@ var io = {
 	 * @param      the port on which the connection should be made (optional)
 	 */
 	init: function (address, port, ssl, username, password) {
-		console.info("Type 'io.debug=true;' to console to see more details.");
+		!io.debug && console.info("Type 'io.debug=true;' to console to see more details.");
 		io.debug && console.debug("io.init(address = " + address + ", port = " + port + ", ssl = " + ssl + ", username = " + username + ", password = " + password + ")");
 
 		io.url = (ssl == true ? "https" : "http") + "://" + address + (port ? ":" + port : '') + "/rest/";


### PR DESCRIPTION
Openhab3 benutzt anderen Namespace für Events als die Vorgängerversion. Funktion zur Abfrage der Version eingebaut, damit entsprechender Namespace gewählt wird.