### PR TITLE
revert custom docu change

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -64,7 +64,6 @@
 - Firefox ignored jQM theme selection for collapsible block headings
 - some drivers threw errors due to empty function io.stopseries and interrupted the page change process (2nd click necessary to change page)
 - iobroker driver did not work with boolean items. A conversion is integrated now.
-- widgets in ./pages/<yourPages>/widgets were not listed in custom docu page. Their docu files must however be available in ./dropins or its subtree
 
 ### Known Bugs
 - if item contains a stringified number (e.g. with leading zero). widget.set converts it back to numeric format - so basic.print can not print it as text

--- a/lib/functions_twig.php
+++ b/lib/functions_twig.php
@@ -143,8 +143,6 @@ function twig_docu($filenames = null)
 			{
 				$filenames = array($filenames);
 				$filenames = array_merge(twig_dir('dropins', '(.*.\.html)'), twig_dir('dropins/widgets', '(.*.\.html)'), twig_dir('dropins/shwidgets', '(.*.\.html)'));
-				if(twig_isdir('pages/'.config_pages.'/widgets'))
-					$filenames = array_merge($filenames, twig_dir('pages/'.config_pages.'/widgets', '(.*.\.html)'));
 			}
 		else
 			$filenames = array($filenames);

--- a/pages/docu/custom/widget_custom.html
+++ b/pages/docu/custom/widget_custom.html
@@ -19,7 +19,7 @@
 	In order to show a docu page for a custom widget, the docu page needs to be created according to the following rules:
 	<ul>
 		<li> Name the docu file "widget_&lt;widgetgroup&gt;.&lt;widget&gt;.html", e.g. widget_mywidgets.myfunction.html</li>
-		<li> Place the docu file in the same directory where the widget files are located (only ./dropins and subtree is possible) </li>
+		<li> Place the docu file in the same directory where the widget files are located (only ./dropins and subtree is working correctly in the docu) </li>
 		<li> Add the following head to the top of your widget file and also your docu file:
 	<div class="twig">
 		<code class="prettyprint">{% filter trim|escape|nl2br %}{% verbatim %}
@@ -48,6 +48,6 @@
 	</ul> <br /> 
 	
 	<h2>Important: The links in the top section of this page have been created out of the available custom widget files. For widgets listed with no active link, the corresponding docu pages have not been found. 
-	If widgets are stored in ./pages/&lt;yourPages&gt;/widgets the docu files must be stored in ./dropins and its subtree. </h2>
+	If widgets are stored in ./pages/&lt;yourPages&gt;/widgets the docu won't work. </h2>
 
 {% endblock %}


### PR DESCRIPTION
widgets from ./pages/mypages can not be loaded in docu mode since files in a different ./pages subdirectory can not be retreived by twig - neither as templates nor as macro files.