### PR TITLE
performance improvement

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### Other New Features
 
 ### Improvements
+- performance increased by avoiding long executions times of frequent jQuery mobile pagecontainer widget calls
 
 ### Updated Libraries
 

--- a/lib/base/base.js
+++ b/lib/base/base.js
@@ -1543,7 +1543,7 @@ var widget = {
 
 			widget.set(item, value);
 			
-			$(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-item*="' + item + '"]').filter(':data("sv-widget")').widget('update', widget.get(item), item) // new jQuery Mobile style widgets
+			$(sv.activePage).find('[data-item*="' + item + '"]').filter(':data("sv-widget")').widget('update', widget.get(item), item) // new jQuery Mobile style widgets
 			
 		}
 	},
@@ -1554,7 +1554,7 @@ var widget = {
 	 * widgets if a new page has been opened. Bind to jquery mobile 'pageshow'.
 	 */
 	refresh: function () {
-		$(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-item]').filter(':data("sv-widget")').widget('update') // new jQuery Mobile style widgets
+		$(sv.activePage).find('[data-item]').filter(':data("sv-widget")').widget('update') // new jQuery Mobile style widgets
 
 		//TODO: call io.run here instead of this in io.run and io.run in root.html
 		// config_driver_realtime needs to be evaluated
@@ -1614,7 +1614,7 @@ var widget = {
 	listeners: function () {
 		var unique = {};
 
-		$(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-item]').each(function (idx) {
+		$(sv.activePage).find('[data-item]').each(function (idx) {
 			if (!($(this).attr('data-widget') == 'status.log')) {
 				var items = widget.explode($(this).attr('data-item'));
 				for (var i = 0; i < items.length; i++) {
@@ -1637,7 +1637,7 @@ var widget = {
 		var unique = {};
 
 		if(jqWidgets == null)
-			jqWidgets = $(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-item*="url:"]');
+			jqWidgets = $(sv.activePage).find('[data-item*="url:"]');
 
 		jqWidgets.each(function (idx) {
 			var items = widget.explode($(this).attr('data-item'));
@@ -1660,7 +1660,7 @@ var widget = {
 	series: function (item) {
 		var unique = {};
 
-		$(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-widget^="plot."][data-item'+(item ? '*="' + item + '"' : '')+']').each(function (idx) {
+		$(sv.activePage).find('[data-widget^="plot."][data-item'+(item ? '*="' + item + '"' : '')+']').each(function (idx) {
 			var items = widget.explode($(this).attr('data-item'));
 			$.each(items, function(idx, currentItem) {
 				if ((!item || currentItem == item) && widget.checkseries(currentItem)) {
@@ -1681,7 +1681,7 @@ var widget = {
 	logs: function (item) {
 		var unique = {};
 
-		$(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-widget="status.log"][data-item'+(item ? '*="' + item + '"' : '')+']').each(function (idx) {
+		$(sv.activePage).find('[data-widget="status.log"][data-item'+(item ? '*="' + item + '"' : '')+']').each(function (idx) {
 			var jqNodes = $(this);
 			var items = widget.explode(jqNodes.attr('data-item'));
 			var count = jqNodes.attr('data-count');
@@ -1708,7 +1708,7 @@ var widget = {
 		var ret = $();
 
 		if (item) {
-			$(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-widget^="plot."][data-item*="' + item + '"]').each(function (idx) {
+			$(sv.activePage).find('[data-widget^="plot."][data-item*="' + item + '"]').each(function (idx) {
 				var items = widget.explode($(this).attr('data-item'));
 				for (var i = 0; i < items.length; i++) {
 					if (items[i] == item) {
@@ -1718,7 +1718,7 @@ var widget = {
 			})
 		}
 		else {
-			ret = $(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-widget^="plot."][data-item]');
+			ret = $(sv.activePage).find('[data-widget^="plot."][data-item]');
 		}
 
 		return ret;
@@ -1735,7 +1735,7 @@ var widget = {
 		var ret = $();
 
 		if (item) {
-			$(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-widget="status.log"][data-item="' + item + '"]').each(function (idx) {
+			$(sv.activePage).find('[data-widget="status.log"][data-item="' + item + '"]').each(function (idx) {
 				var items = widget.explode($(this).attr('data-item'));
 				for (var i = 0; i < items.length; i++) {
 					if (items[i] == item) {
@@ -1745,7 +1745,7 @@ var widget = {
 			})
 		}
 		else {
-			ret = $(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-widget="status.log"][data-item]');
+			ret = $(sv.activePage).find('[data-widget="status.log"][data-item]');
 		}
 
 		return ret;
@@ -1781,7 +1781,7 @@ $(document).on("pagecontainerbeforeload", function(event, data) {
  $(document).on('pagecontainerbeforetransition', function(event,ui) {
 	if (ui.prevPage!= undefined && ui.toPage[0].id != ui.prevPage[0].id) { 
 		io.stopseries ();
-		$(":mobile-pagecontainer").pagecontainer( "getActivePage" ).find('[data-widget]').filter(':data("sv-widget")').widget('exit');
+		$(sv.activePage).find('[data-widget]').filter(':data("sv-widget")').widget('exit');
 	}
 });
 
@@ -1790,7 +1790,7 @@ $(document).on("pagecontainerbeforeload", function(event, data) {
 * in order to force a reload when the page is being left and thus remove the special ressources from the DOM
 */
 $(document).on('pagecontainerchange', function(event, ui) {
-	$(":mobile-pagecontainer").pagecontainer( "getActivePage" ).filter('#config, #templatechecker, #widget_assistant')
+	$(sv.activePage).filter('#config, #templatechecker, #widget_assistant')
 		.find('[href^="index.php"]').attr('data-ajax', false) 		// modify all internal links to block ajax navigation
 		.end().each(function(){										// block browser back / foreward buttons
 			var currentURL = $(this).context.baseURI;

--- a/lib/base/base.php
+++ b/lib/base/base.php
@@ -200,6 +200,7 @@
  * -----------------------------------------------------------------------------
  */
 	var sv = {
+		activePage: {},
 		config: {
 			version: '<?php echo config_version_full ?>',
 			icon0: '<?php echo config_design_icon0 ?>',
@@ -210,7 +211,7 @@
 <?php
 				foreach ($GLOBALS['config'] as $key => $value) {
 					if (strpos($key, 'driver_') === 0) {
-						echo substr($key, 7) . ": '$value',\r\n";
+						echo substr($key, 7) . ": '". $value . "',";
 					}
 				}
 ?>

--- a/pages/base/root.html
+++ b/pages/base/root.html
@@ -209,6 +209,8 @@
 	// Do some actions before page is shown
 	// and run the io  with all widgets
 	$(document).on('pagecontainerbeforeshow', function () {
+		// get active page into an object in order to speed up item / widget updates
+		sv.activePage = $(":mobile-pagecontainer").pagecontainer("getActivePage");
 		fx.init();
 		repeater.init();
 		io.run();


### PR DESCRIPTION
$(":mobile-pagecontainer").pagecontainer("getActivePage") takes more time than $.mobile.activePage. On large pages with lots of widgets this may result in 50% longer processing time.
We store the active page in an object "sv.activePage" in order to get a faster access to its properties.
