### PR TITLE
Image widget: check for file headers

### DIFF
--- a/widgets/multimedia.html
+++ b/widgets/multimedia.html
@@ -32,7 +32,8 @@
 * Displays an image witch is been reloaded after a given time
 *
 * @param {id=} unique id for this widget
-* @param {text} the path/url or item to the image. For squeezebox create an item with the following value: 'http://IP:PORT/music/current/cover.jpg?player=MACADDRESS'
+* @param {text} the path/url or item to the image. For squeezebox create an item with the following value: 'http://IP:WEBPORT/music/current/cover.jpg?player=MACADDRESS'.
+  Furthermore, make sure to list your SV server address/IP in the LMS Server setting Advanced/Security/CORS accepted hosts.
 * @param {text(none,corner,corner-bottom,fill)=none} the mode: 'none', 'corner', 'corner-bottom', 'fill' (optional, default 'none') (optional)
 * @param {text=10i} the reload-time in duration-format or defined as an item that retriggers a refresh (optional, default '10i')
 * @param {image=} the path/url to a default image that is shown on error and startup
@@ -148,7 +149,7 @@
 
 	<div{% if not id is empty %} id="{{ uid(page, id) }}"{% endif %} class="slideshow cycle-slideshow" data-widget="multimedia.slideshow"
 		data-cycle-log="false" data-cycle-speed="2000" data-cycle-timeout="{{ delay|default(4) * 1000 }}" data-cycle-reverse="{{ reverse|default(0) }}"
-		data-repeat ="{{ refresh|default('1d') }}" data-directory = "{{ dir }}" 
+		data-repeat ="{{ refresh|default('1d') }}" data-directory = "{{ dir }}"
 		data-item="{{ item_prev }}, {{ item_next }}, {{ item_stop }}, {{ item_start }}">
 
 	</div>

--- a/widgets/multimedia.js
+++ b/widgets/multimedia.js
@@ -15,7 +15,7 @@ $.widget("sv.multimedia_image", $.sv.widget, {
         this.element.attr('data-repeat-milliseconds', Number(new Date().duration(this.element.attr('data-repeat'))));
       this.element.attr('stopTimer', 'false');
     },
-	
+
     _update: function(response) {
       var widget_url = this.element.attr('data-url');
       var resp = Array.isArray(response) ? response[0]: response;
@@ -24,10 +24,24 @@ $.widget("sv.multimedia_image", $.sv.widget, {
         var img_base = widget_url + ((widget_url.indexOf('?') == -1) ? '?' : '&');
       else
         var img_base = resp + ((resp.indexOf('?') == -1) ? '?' : '&');
-
 	  img = img_base + '_=' + new Date().getTime();
 	  refreshing = this.element.attr('data-repeat') ? this.element.attr('data-repeat') : 'refresh by item';
 	  // console.log("Response: " + response + " Update Multimedia Image: " + img + ", repeat: " + refreshing);
+
+    var self = this;
+    fetch(img, {method: 'HEAD'})
+    .then ( function(response) {
+      let contentType = response.headers.get("content-type");
+      if (contentType.startsWith("text/html"))
+      {
+        replacement = self.element.attr("onerror").match(/this.src=\'(.*)\'/)[1];
+        console.log("Issue with " + img + ". Replacing it with default error image " + replacement);
+        self.element.attr('src', replacement);
+      }
+    }).catch (
+      function(error) {
+      console.log('Problem getting header of media file: \n', error);
+    });
 	  this.element.attr('src', img);
       if (this.element.attr('data-repeat') && ! img.startsWith('_='))
       {
@@ -44,7 +58,7 @@ $.widget("sv.multimedia_image", $.sv.widget, {
         console.log("Clear multimediaimage timer " + this._ticker);
         this._ticker = null;
     },
-	
+
 	// error handling for localized URL (called via ./lib/multimedia/camimage.php)
 	// only called if widget parameter 'localized' = 'true'
 	loadError: function(){
@@ -92,7 +106,7 @@ $.widget("sv.multimedia_slideshow", $.sv.widget, {
 	options: {
 		directory: ''
 	},
-	
+
 	_currentErrorNotification: 0,
 
 	_create: function() {
@@ -124,7 +138,7 @@ $.widget("sv.multimedia_slideshow", $.sv.widget, {
 		var currentSet = [];
 		var dataByFile = [];
 		var setChanged = false;
-		
+
 		$.ajax({
 			dataType: "json",
 			url: 'lib/getdir.php' + '?directory=' + this.options.directory + '&filter=' + filter,
@@ -139,10 +153,10 @@ $.widget("sv.multimedia_slideshow", $.sv.widget, {
 				// check for deleted files and remove them from html
 				i = 0;
 				$.each(element.find('img'), function(index){
-					currentSet[i] = $(this).attr('src'); 
+					currentSet[i] = $(this).attr('src');
 					if (!dataByFile.includes(currentSet[i]))
 					$(this).remove();
-					setChanged = true; 	
+					setChanged = true;
 					i++;
 				});
 				// check for new files and append them to html
@@ -152,12 +166,12 @@ $.widget("sv.multimedia_slideshow", $.sv.widget, {
 						element.cycle('add', newSlide);
 					}
 				}
-				
+
 				if (setChanged){
 					element.cycle('reinit');
 					setChanged = false;
 				}
-		
+
 				if (this._currentErrorNotification != 0){
 					notify.remove(this._currentErrorNotification);
 					this._currentErrorNotification = 0;
@@ -264,7 +278,7 @@ $.widget("sv.multimedia_playpause", $.sv.widget, {
   },
     _update: function(response){
         if (response[0] == 0 && response[1] == 0 || response[2] == 1)  {
-            this.element.find('.mm_play, .mm_pause').hide().end().find('.mm_stop').show(); 
+            this.element.find('.mm_play, .mm_pause').hide().end().find('.mm_stop').show();
             console.log("Playpause: Stop .."+this.element.val());
             this.element.attr('data-val', 0);
             }

--- a/widgets/multimedia.js
+++ b/widgets/multimedia.js
@@ -32,7 +32,7 @@ $.widget("sv.multimedia_image", $.sv.widget, {
     fetch(img, {method: 'HEAD'})
     .then ( function(response) {
       let contentType = response.headers.get("content-type");
-      if (contentType.startsWith("text/html"))
+      if (!contentType.startsWith("image/"))
       {
         replacement = self.element.attr("onerror").match(/this.src=\'(.*)\'/)[1];
         console.log("Issue with " + img + ". Replacing it with default error image " + replacement);


### PR DESCRIPTION
If the header response of a URL doesn't correspond with the image MIME type the standard error image will get displayed.

This is esp. useful for implementing cover images from Logitech Mediaserver. Sometimes you otherwise might have issues when playing radio stations or songs without covers. 

Make sure to allow CORS on the remote system providing the image otherwise there will be enoying messages in the console. Maybe there is an idea to prevent this? Maybe the check only takes place if there is a problem with image loading?