### PR TITLE
Add option to add css style to slider widget

### DIFF
--- a/pages/docu/basic/widget_basic.slider.html
+++ b/pages/docu/basic/widget_basic.slider.html
@@ -69,4 +69,16 @@
 		{{ basic.slider('', 'bath.light.value', 0, 255, 5, '', 'both') }}
 	</div>
 
+	Style
+	<div class="twig">
+		<code class="prettyprint">
+			&#123;&#123; basic.slider('', 'bath.light.color_temperture',0, 255, 5, '', 'none', '', '', 1, 'linear-gradient(90deg, rgb(229, 234, 255), rgb(255, 177, 111))') &#125;&#125;<br>
+			&#123;&#123; basic.slider('', 'bath.light.color_temperture',0, 255, 5, '', 'none', '', '', 1, 'linear-gradient(90deg, rgb(255, 0, 0), rgb(0, 0, 255))') &#125;&#125;
+		</code>
+	</div>
+	<div class="html">
+		{{ basic.slider('', 'bath.light.color_temperture',0, 255, 5, '', 'none', '', '', 1, 'linear-gradient(90deg, rgb(229, 234, 255), rgb(255, 177, 111))') }}<br>
+		{{ basic.slider('', 'bath.light.color_temperture',0, 255, 5, '', 'none', '', '', 1, 'linear-gradient(90deg, rgb(255, 0, 0), rgb(0, 0, 255))') }}
+	</div>
+
 {% endblock %}

--- a/widgets/basic.html
+++ b/widgets/basic.html
@@ -531,12 +531,13 @@
 * @param {value=} the minimum value to display if the slider is moved to total left if this should differ from sent/received value (optional, default like min)
 * @param {value=} the maximum value to display to total right if this should differ from sent/received value (optional, default like max)
 * @param {value=1} 'live mode': if enabled, values will be sent during sliding. '0' sends values only when sliding is stopped, after click into track or if value is edited in input field. (optional, default = 1)
+* @param {value=} set a colour for the slider track like: linear-gradient(90deg, rgb(229, 234, 255), rgb(255, 177, 111)) (optional)
 *
 * @see misc/fundamentals#Items
 */
-{% macro slider(id, item, min, max, step, orientation, value_display, min_display, max_display, live) %}
+{% macro slider(id, item, min, max, step, orientation, value_display, min_display, max_display, live, style) %}
 	<input{% if not id is empty %} id="{{ uid(page, id) }}"{% endif %} data-widget="basic.slider" data-item="{{ item }}"
-		type="range" value="0" min="{{ min_display|default(min)|default(0) }}" max="{{ max_display|default(max)|default(255) }}" step="{{ step|default(5) }}" data-min-send="{{ min|default(0) }}" data-max-send="{{ max|default(255) }}" data-live="{{ live|default(1) }}"
+		type="range" value="0" min="{{ min_display|default(min)|default(0) }}" max="{{ max_display|default(max)|default(255) }}" step="{{ step|default(5) }}" data-min-send="{{ min|default(0) }}" data-max-send="{{ max|default(255) }}" data-live="{{ live|default(1) }}" data-style="{{ style|default('') }}"
 		data-orientation="{{ orientation|default('horizontal') }}" data-handleinfo="{{ value_display == 'handle' or value_display == 'both' }}" data-highlight="true" class="{{ value_display|default('input') == 'input' or value_display == 'both' ? '' : 'ui-slider-no-input' }}" />
 {% endmacro %}
 

--- a/widgets/basic.js
+++ b/widgets/basic.js
@@ -950,7 +950,8 @@ $.widget("sv.basic_slider", $.sv.widget, {
 		max: 255,
 		'min-send': 0,
 		'max-send': 255,
-		'live': 1
+		'live': 1,
+		'style': ''
 	},
 
 	_mem: null,
@@ -978,6 +979,12 @@ $.widget("sv.basic_slider", $.sv.widget, {
 		else {
 			this._mem = val;
 		}
+		if (this.options['style'] != ''){
+			//add for colouring the slider track
+			this.element.next('.ui-slider-track').css("background-image", this.options['style']);
+			this.element.next('.ui-slider-track').children(".ui-slider-bg").css("background-image", "none");
+			this.element.next('.ui-slider-track').children(".ui-slider-bg").css("background-color", "transparent");
+		};
 	},
 
 	_events: {


### PR DESCRIPTION
This change was already available in smartVISU-newstuff/widgets, but was lost during last version change.
Makes ist easy to build a silder for color temperature lights etc.

![image](https://github.com/Martin-Gleiss/smartvisu/assets/1830710/730dabbe-c01e-44ba-a5e4-7557832edb84)
